### PR TITLE
Fix runaway dev server process

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -37,13 +37,16 @@ if (process.env.NODE_ENV !== "development") {
 
 app.use(historyFallback());
 
-app.use(devMiddlware(compiler));
+const instance = devMiddlware(compiler);
+
+app.use(instance);
 
 const server = killable(http.createServer(app));
 
 ["SIGINT", "SIGTERM"].forEach(sig => {
   process.on(sig, () => {
     console.info(`Process Ended via ${sig}`);
+    instance.close();
     server.kill();
   });
 });


### PR DESCRIPTION
Prevent dev server process from continuing in the background when killed with `ctrl + C` in the terminal.