### PR TITLE
Fix update-schema build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /build
 /stats.json
 /dashboard.tgz
+/.schema
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "spec": "node scripts test.js --env=jsdom",
     "start": "NODE_ENV=development yarn build:vendor && NODE_ENV=development yarn dev-server",
     "test": "yarn check-version && yarn build && yarn lint && yarn spec --coverage",
+    "fetch-schema": "node scripts fetch-schema",
     "update-schema": "node scripts update-schema",
     "upload-artifacts": "node scripts upload-artifacts"
   },
@@ -60,6 +61,8 @@
     "@babel/preset-react": "^7.0.0",
     "@material-ui/core": "^3.0.0",
     "@material-ui/icons": "^3.0.0",
+    "@octokit/plugin-throttling": "^2.4.0",
+    "@octokit/rest": "^16.23.2",
     "acorn": "^6.1.1",
     "acorn-dynamic-import": "^4.0.0",
     "add-asset-html-webpack-plugin": "^3.1.3",
@@ -203,5 +206,6 @@
     "graphql-config/**/graphql": "0.13.0",
     "graphql-import/**/graphql": "0.13.0",
     "js-yaml": "^3.13.0"
-  }
+  },
+  "graphQLSchemaRef": "5a9e138d"
 }

--- a/scripts/fetch-schema.js
+++ b/scripts/fetch-schema.js
@@ -1,0 +1,134 @@
+import fs from "fs";
+import https from "https";
+import path from "path";
+
+import fsPromise from "./fsPromise";
+import api from "./githubApi";
+
+import pkg from "../package.json";
+
+const MAX_PARALLEL_REQUESTS = 5;
+
+const schemaDir = path.resolve(".schema");
+const lockFilePath = path.join(schemaDir, "lock.json");
+
+const readLockFile = () =>
+  fsPromise.readFile(lockFilePath, "utf-8").then(
+    contents => JSON.parse(contents),
+    error => {
+      if (error.code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    },
+  );
+
+const updateLockFile = contents =>
+  fsPromise.writeFile(lockFilePath, JSON.stringify(contents, null, 2), "utf-8");
+
+const fetchSchemaContents = (ref = "master") => {
+  console.log(`fetching graphql schema from sensu-go/${ref}`);
+  return api.repos
+    .getContents({
+      owner: "sensu",
+      repo: "sensu-go",
+      path: "backend/apid/graphql/schema",
+      ref,
+    })
+    .then(result => result.data.filter(item => /\.graphql$/.test(item.name)));
+};
+
+const fetch = (url, filePath) =>
+  new Promise((resolve, reject) => {
+    const done = (error, ...args) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(args);
+      }
+    };
+
+    const fileStream = fs.createWriteStream(filePath);
+
+    const request = https.get(url, response => {
+      response.pipe(fileStream);
+      fileStream.on("finish", () => {
+        fileStream.close(done);
+      });
+    });
+
+    request.on("error", done);
+  });
+
+const lockFilePromise = readLockFile();
+
+const exists = filePath =>
+  fsPromise.stat(filePath).then(
+    () => true,
+    error => {
+      if (error.code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    },
+  );
+
+const updateLocal = remoteItem => {
+  const filePath = path.join(schemaDir, remoteItem.name);
+
+  return lockFilePromise
+    .then(localContents =>
+      localContents.find(
+        localItem =>
+          localItem.name === remoteItem.name &&
+          localItem.sha === remoteItem.sha,
+      ),
+    )
+    .then(currentItem => !!currentItem && exists(filePath))
+    .then(localFileExists => {
+      if (!localFileExists) {
+        console.log("updating local", filePath);
+        return fetch(remoteItem.download_url, filePath);
+      }
+      return Promise.resolve();
+    });
+};
+
+const mapPromiseParallel = (items, max, callback) =>
+  new Promise((resolve, reject) => {
+    const remaining = [...items];
+    const result = [];
+
+    let count = 0;
+
+    const run = () => {
+      if (remaining.length === 0 && count === 0) {
+        resolve(result);
+      }
+
+      if (remaining.length && count < max) {
+        count += 1;
+        callback(remaining.pop()).then(() => {
+          count -= 1;
+          run();
+        }, reject);
+        run();
+      }
+    };
+
+    run();
+  });
+
+fsPromise
+  .mkdir(schemaDir)
+  .catch(error => {
+    if (error.code !== "EEXIST") {
+      throw error;
+    }
+  })
+  .then(() => fetchSchemaContents(pkg.graphQLSchemaRef))
+  .then(remoteContents =>
+    mapPromiseParallel(remoteContents, MAX_PARALLEL_REQUESTS, updateLocal)
+      .then(() => remoteContents.map(({ name, sha }) => ({ name, sha })))
+      .then(items => updateLockFile(items)),
+  );

--- a/scripts/fsPromise.js
+++ b/scripts/fsPromise.js
@@ -1,0 +1,18 @@
+import fs from "fs";
+
+const callback = (resolve, reject) => (error, ...args) => {
+  if (error) {
+    reject(error);
+  } else {
+    resolve(args);
+  }
+};
+
+export default Object.keys(fs).reduce((result, key) => {
+  // eslint-disable-next-line no-param-reassign
+  result[key] = (...args) =>
+    new Promise((resolve, reject) => {
+      fs[key](...args, callback(resolve, reject));
+    });
+  return result;
+}, {});

--- a/scripts/githubApi.js
+++ b/scripts/githubApi.js
@@ -1,0 +1,28 @@
+import OctokitRest from "@octokit/rest";
+import OctokitPluginThrottling from "@octokit/plugin-throttling";
+
+OctokitRest.plugin(OctokitPluginThrottling);
+
+export default new OctokitRest({
+  throttle: {
+    onRateLimit: (retryAfter, options) => {
+      console.warn(
+        `Request quota exhausted for request ${options.method} ${options.url}`,
+      );
+
+      if (options.request.retryCount === 0) {
+        // only retries once
+        console.log(`Retrying after ${retryAfter} seconds!`);
+        return true;
+      }
+
+      return false;
+    },
+    onAbuseLimit: (retryAfter, options) => {
+      // does not retry, only logs a warning
+      console.warn(
+        `Abuse detected for request ${options.method} ${options.url}`,
+      );
+    },
+  },
+});

--- a/scripts/update-schema.js
+++ b/scripts/update-schema.js
@@ -9,7 +9,7 @@ import { writeFileSync, readFileSync } from "fs";
 import { printSchema, buildASTSchema, extendSchema, parse } from "graphql";
 import chalk from "chalk";
 
-const serverSchemaPath = resolve("../backend/apid/graphql/schema/*.graphql");
+const serverSchemaPath = resolve(".schema/*.graphql");
 const clientSchemaPath = resolve("src/schema/client.graphql");
 const combinedFilePath = resolve("src/schema/combined.graphql");
 

--- a/src/app/component/partial/ClearSilencedEntriesDialog/Dialog.js
+++ b/src/app/component/partial/ClearSilencedEntriesDialog/Dialog.js
@@ -64,9 +64,7 @@ class ClearSilencedEntriesDialog extends React.PureComponent {
         id
         deleted @client
         name
-        creator {
-          username
-        }
+        creator
       }
 
       ${SilenceExpiration.fragments.silence}
@@ -111,7 +109,7 @@ class ClearSilencedEntriesDialog extends React.PureComponent {
       </TableOverflowCell>
       <TableCell>
         <ResourceDetails
-          title={<Maybe value={silence.creator}>{u => u.username}</Maybe>}
+          title={<Maybe value={silence.creator} fallback="Unspecified" />}
         />
       </TableCell>
     </TableSelectableRow>

--- a/src/app/component/partial/SilencesList/SilencesListItem.js
+++ b/src/app/component/partial/SilencesList/SilencesListItem.js
@@ -60,9 +60,7 @@ class SilencesListItem extends React.Component {
         name
         begin
         reason
-        creator {
-          username
-        }
+        creator
       }
 
       ${SilenceExpiration.fragments.silence}
@@ -118,18 +116,20 @@ class SilencesListItem extends React.Component {
               }}
             >
               <Maybe value={silence.creator}>
-                <Chip
-                  avatar={
-                    <Avatar>
-                      <FaceIcon />
-                    </Avatar>
-                  }
-                  label={silence.creator.username}
-                  style={{
-                    // TODO: ideally have Chip scale to current fontSize(?)
-                    transform: "scale(0.87)",
-                  }}
-                />
+                {creator => (
+                  <Chip
+                    avatar={
+                      <Avatar>
+                        <FaceIcon />
+                      </Avatar>
+                    }
+                    label={creator}
+                    style={{
+                      // TODO: ideally have Chip scale to current fontSize(?)
+                      transform: "scale(0.87)",
+                    }}
+                  />
+                )}
               </Maybe>
             </TableCell>
           </Hidden>

--- a/src/schema/combined.graphql
+++ b/src/schema/combined.graphql
@@ -910,6 +910,9 @@ type LocalNetwork {
 
 """The root query for implementing GraphQL mutations."""
 type Mutation {
+  """Create or overrwrite resource from given wrapped resource."""
+  putWrapped(raw: String!): PutWrappedPayload!
+
   """Creates a new check."""
   createCheck(input: CreateCheckInput!): CreateCheckPayload
 
@@ -1193,6 +1196,17 @@ type ProxyRequests {
   splayCoverage: Int!
 }
 
+type PutWrappedPayload {
+  """The newly created / updated resource"""
+  node: Node
+
+  """
+  Includes any failed preconditions or unrecoverable errors that occurred while
+  executing the mutation.
+  """
+  errors: [Error!]!
+}
+
 """The query root of Sensu's GraphQL interface."""
 type Query {
   """Current viewer."""
@@ -1219,6 +1233,14 @@ type Query {
     """The ID of an object."""
     id: ID!
   ): Node
+
+  """
+  Node fetches an object given its ID and returns it as wrapped resource.
+  """
+  wrappedNode(
+    """The ID of an object."""
+    id: ID!
+  ): JSON
 
   """Describes state of authorization tokens"""
   auth: Auth
@@ -1352,7 +1374,7 @@ type Silenced implements Node & Namespaced & HasMetadata {
   expireOnResolve: Boolean!
 
   """Creator is the author of the silenced entry"""
-  creator: User!
+  creator: String!
 
   """Check is the name of the check event to be silenced."""
   check: CheckConfig
@@ -1403,6 +1425,10 @@ enum SilencesListOrder {
   BEGIN_DESC
 }
 
+"""
+StandardError is the standard implementation of an error that includes a
+message.
+"""
 type StandardError implements Error {
   """The field associated with the error."""
   input: String

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,53 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@octokit/endpoint@^3.2.0":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-3.2.3.tgz#bd9aea60cd94ce336656b57a5c9cb7f10be8f4f3"
+  integrity sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==
+  dependencies:
+    deepmerge "3.2.0"
+    is-plain-object "^2.0.4"
+    universal-user-agent "^2.0.1"
+    url-template "^2.0.8"
+
+"@octokit/plugin-throttling@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-2.4.0.tgz#add1bd6a797aa210ce860e8bbe7f7505ba5e4d99"
+  integrity sha512-0bYfgQdqAtWiqXvS6oKMiousTno+e3pFoaYS57LpAp8p56Far49/vpGvbEvBUuNyoUFgOcTGm5WTpO1IPptHuQ==
+  dependencies:
+    bottleneck "^2.15.3"
+
+"@octokit/request@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-2.4.2.tgz#87c36e820dd1e43b1629f4f35c95b00cd456320b"
+  integrity sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==
+  dependencies:
+    "@octokit/endpoint" "^3.2.0"
+    deprecation "^1.0.1"
+    is-plain-object "^2.0.4"
+    node-fetch "^2.3.0"
+    once "^1.4.0"
+    universal-user-agent "^2.0.1"
+
+"@octokit/rest@^16.23.2":
+  version "16.23.2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.23.2.tgz#975e84610427c4ab6c41bec77c24aed9b7563db4"
+  integrity sha512-ZxiZMaCuqBG/IsbgNRVfGwYsvBb5DjHuMGjJgOrinT+/b+1j1U7PiGyRkHDJdjTGA6N/PsMC2lP2ZybX9579iA==
+  dependencies:
+    "@octokit/request" "2.4.2"
+    atob-lite "^2.0.0"
+    before-after-hook "^1.4.0"
+    btoa-lite "^1.0.0"
+    deprecation "^1.0.1"
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+    lodash.uniq "^4.5.0"
+    octokit-pagination-methods "^1.1.0"
+    once "^1.4.0"
+    universal-user-agent "^2.0.0"
+    url-template "^2.0.8"
+
 "@types/async@2.0.49":
   version "2.0.49"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.49.tgz#92e33d13f74c895cb9a7f38ba97db8431ed14bc0"
@@ -1627,6 +1674,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+atob-lite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
+  integrity sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
+
 atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1781,6 +1833,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+before-after-hook@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
+  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1831,6 +1888,11 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bottleneck@^2.15.3:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.17.1.tgz#a45809e4cdf5326e14dc69970f4af7029e22c0f4"
+  integrity sha512-ARJKJRNq6+W7BBYZnkqA1F4+HDclht7QyRJl2haAVtD7xBTG8Prpy6huO+canGLUxZaRrek8U/0NjTvoXACsaQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1959,6 +2021,11 @@ bser@^2.0.0:
   integrity sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
   dependencies:
     node-int64 "^0.4.0"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
+  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -2688,15 +2755,15 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@3.2.0, deepmerge@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
+  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
+
 deepmerge@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.0.tgz#511a54fff405fc346f0240bb270a3e9533a31102"
   integrity sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw==
-
-deepmerge@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
-  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -2748,6 +2815,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+deprecation@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
+  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -5679,6 +5751,11 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -5716,10 +5793,20 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
@@ -5759,6 +5846,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+macos-release@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.2.0.tgz#ab58d55dd4714f0a05ad4b0e90f4370fef5cdea8"
+  integrity sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -6175,6 +6267,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
+  integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -6464,6 +6561,11 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
+octokit-pagination-methods@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
+  integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -6528,6 +6630,14 @@ os-locale@^3.0.0, os-locale@^3.1.0:
     execa "^1.0.0"
     lcid "^2.0.0"
     mem "^4.0.0"
+
+os-name@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
+  integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
+  dependencies:
+    macos-release "^2.2.0"
+    windows-release "^3.1.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -8660,6 +8770,13 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
+  integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
+  dependencies:
+    os-name "^3.0.0"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -8715,6 +8832,11 @@ url-search-params-polyfill@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-2.0.3.tgz#466b451df7e707f9a0de601fa39b0a5816402dcd"
   integrity sha512-DLQzhOippXPJOS+XJOwZGV5tILjGhIQEPbjEDAvTh5nWcZOpbGZG0xXj/lss+dAA1oC/8HYR5xFfC28TW0b+VQ==
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url@0.10.3:
   version "0.10.3"
@@ -9022,6 +9144,13 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+windows-release@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.2.0.tgz#8122dad5afc303d833422380680a79cdfa91785f"
+  integrity sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
+  dependencies:
+    execa "^1.0.0"
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -9088,11 +9217,6 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
-
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
@@ -9100,6 +9224,11 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
Closes #50

Add new `fetch-schema` script to fix the reference to the server GraphQL schema which broke as a result of the repo split. 

Fixes compatibility with the schema changes from https://github.com/sensu/sensu-go/pull/2843