### PR TITLE
Add toolbarItems callback prop to view components

### DIFF
--- a/src/lib/component/partial/CheckDetailsContainer/CheckDetailsContainer.js
+++ b/src/lib/component/partial/CheckDetailsContainer/CheckDetailsContainer.js
@@ -14,11 +14,13 @@ class CheckDetailsContainer extends React.PureComponent {
     check: PropTypes.object,
     loading: PropTypes.bool.isRequired,
     refetch: PropTypes.func,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     check: null,
     refetch: () => null,
+    toolbarItems: undefined,
   };
 
   static fragments = {
@@ -37,14 +39,18 @@ class CheckDetailsContainer extends React.PureComponent {
   };
 
   render() {
-    const { check, loading, refetch } = this.props;
+    const { check, loading, refetch, toolbarItems } = this.props;
 
     return (
       <Loader loading={loading} passthrough>
         {check && (
           <React.Fragment>
             <Content marginBottom>
-              <Toolbar check={check} refetch={refetch} />
+              <Toolbar
+                toolbarItems={toolbarItems}
+                check={check}
+                refetch={refetch}
+              />
             </Content>
 
             <Grid container spacing={16}>

--- a/src/lib/component/partial/CheckDetailsContainer/CheckDetailsToolbar.js
+++ b/src/lib/component/partial/CheckDetailsContainer/CheckDetailsToolbar.js
@@ -25,11 +25,13 @@ class CheckDetailsToolbar extends React.Component {
   static propTypes = {
     check: PropTypes.object,
     refetch: PropTypes.func,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     check: null,
     refetch: () => null,
+    toolbarItems: ({ items }) => items,
   };
 
   static fragments = {
@@ -51,62 +53,66 @@ class CheckDetailsToolbar extends React.Component {
   };
 
   render() {
-    const { check, refetch } = this.props;
+    const { check, refetch, toolbarItems } = this.props;
 
     return (
       <Toolbar
         right={
           <ToolbarMenu>
-            <ToolbarMenu.Item id="execute " visible="always">
-              <ExecuteAction check={check}>
-                {handler => <QueueExecutionMenuItem onClick={handler} />}
-              </ExecuteAction>
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item
-              id="silence"
-              visible={check.isSilenced ? "never" : "if-room"}
-            >
-              <SilenceAction check={check} onDone={refetch}>
-                {dialog => (
-                  <SilenceMenuItem
-                    onClick={dialog.open}
-                    disabled={dialog.canOpen}
-                  />
-                )}
-              </SilenceAction>
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item
-              id="unsilence"
-              visible={check.isSilenced ? "if-room" : "never"}
-            >
-              <ClearSilenceAction record={check} onDone={refetch}>
-                {dialog => (
-                  <UnsilenceMenuItem
-                    onClick={dialog.open}
-                    disabled={!dialog.canOpen}
-                  />
-                )}
-              </ClearSilenceAction>
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item
-              id={check.publish ? "unpublish" : "publish"}
-              visible="if-room"
-            >
-              {check.publish ? (
-                <UnpublishAction check={check}>
-                  {handler => <UnpublishMenuItem onClick={handler} />}
-                </UnpublishAction>
-              ) : (
-                <PublishAction check={check}>
-                  {handler => <PublishMenuItem onClick={handler} />}
-                </PublishAction>
-              )}
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item id="delete" visible="never">
-              <DeleteAction check={check}>
-                {handler => <DeleteMenuItem onClick={handler} />}
-              </DeleteAction>
-            </ToolbarMenu.Item>
+            {toolbarItems({
+              items: [
+                <ToolbarMenu.Item key="execute " visible="always">
+                  <ExecuteAction check={check}>
+                    {handler => <QueueExecutionMenuItem onClick={handler} />}
+                  </ExecuteAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item
+                  key="silence"
+                  visible={check.isSilenced ? "never" : "if-room"}
+                >
+                  <SilenceAction check={check} onDone={refetch}>
+                    {dialog => (
+                      <SilenceMenuItem
+                        onClick={dialog.open}
+                        disabled={dialog.canOpen}
+                      />
+                    )}
+                  </SilenceAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item
+                  key="unsilence"
+                  visible={check.isSilenced ? "if-room" : "never"}
+                >
+                  <ClearSilenceAction record={check} onDone={refetch}>
+                    {dialog => (
+                      <UnsilenceMenuItem
+                        onClick={dialog.open}
+                        disabled={!dialog.canOpen}
+                      />
+                    )}
+                  </ClearSilenceAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item
+                  key={check.publish ? "unpublish" : "publish"}
+                  visible="if-room"
+                >
+                  {check.publish ? (
+                    <UnpublishAction check={check}>
+                      {handler => <UnpublishMenuItem onClick={handler} />}
+                    </UnpublishAction>
+                  ) : (
+                    <PublishAction check={check}>
+                      {handler => <PublishMenuItem onClick={handler} />}
+                    </PublishAction>
+                  )}
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item key="delete" visible="never">
+                  <DeleteAction check={check}>
+                    {handler => <DeleteMenuItem onClick={handler} />}
+                  </DeleteAction>
+                </ToolbarMenu.Item>,
+              ],
+            })}
           </ToolbarMenu>
         }
       />

--- a/src/lib/component/partial/ChecksList/ChecksListHeader.js
+++ b/src/lib/component/partial/ChecksList/ChecksListHeader.js
@@ -69,14 +69,14 @@ class ChecksListHeader extends React.PureComponent {
 
     return (
       <ToolbarMenu>
-        <ToolbarMenu.Item id="filter-by-subscription" visible="if-room">
+        <ToolbarMenu.Item key="filter-by-subscription" visible="if-room">
           <SelectMenuItem title="Subscription" onChange={this.updateFilter}>
             {subscriptions.map(val => (
               <ToolbarSelectOption key={val} value={val} />
             ))}
           </SelectMenuItem>
         </ToolbarMenu.Item>
-        <ToolbarMenu.Item id="sort" visible="if-room">
+        <ToolbarMenu.Item key="sort" visible="if-room">
           <ListSortSelector
             options={[{ label: "Name", value: "NAME" }]}
             onChangeQuery={onChangeQuery}
@@ -103,7 +103,7 @@ class ChecksListHeader extends React.PureComponent {
 
     return (
       <ToolbarMenu>
-        <ToolbarMenu.Item id="queue" visible="always">
+        <ToolbarMenu.Item key="queue" visible="always">
           <QueueExecutionMenuItem
             disabled={selectedNonKeepalives.length === 0}
             onClick={this.props.onClickExecute}
@@ -111,7 +111,7 @@ class ChecksListHeader extends React.PureComponent {
           />
         </ToolbarMenu.Item>
         <ToolbarMenu.Item
-          id="silence"
+          key="silence"
           visible={allSelectedSilenced ? "never" : "if-room"}
         >
           <SilenceMenuItem
@@ -120,7 +120,7 @@ class ChecksListHeader extends React.PureComponent {
           />
         </ToolbarMenu.Item>
         <ToolbarMenu.Item
-          id="unsilence"
+          key="unsilence"
           visible={allSelectedUnsilenced ? "never" : "if-room"}
         >
           <UnsilenceMenuItem
@@ -129,21 +129,21 @@ class ChecksListHeader extends React.PureComponent {
           />
         </ToolbarMenu.Item>
         {!published ? (
-          <ToolbarMenu.Item id="publish" visible="if-room">
+          <ToolbarMenu.Item key="publish" visible="if-room">
             <PublishMenuItem
               description="Publish selected checks."
               onClick={() => this.props.onClickSetPublish(true)}
             />
           </ToolbarMenu.Item>
         ) : (
-          <ToolbarMenu.Item id="unpublish" visible="if-room">
+          <ToolbarMenu.Item key="unpublish" visible="if-room">
             <UnpublishMenuItem
               description="Unpublish selected checks."
               onClick={() => this.props.onClickSetPublish(false)}
             />
           </ToolbarMenu.Item>
         )}
-        <ToolbarMenu.Item id="delete" visible="never">
+        <ToolbarMenu.Item key="delete" visible="never">
           {menu => (
             <ConfirmDelete
               identifier={

--- a/src/lib/component/partial/ChecksList/ChecksListItem.js
+++ b/src/lib/component/partial/ChecksList/ChecksListItem.js
@@ -109,33 +109,33 @@ class CheckListItem extends React.Component {
           >
             {() => (
               <ToolbarMenu>
-                <ToolbarMenu.Item id="queue" visible="never">
+                <ToolbarMenu.Item key="queue" visible="never">
                   <QueueExecutionMenuItem
                     disabled={check.name === "keepalive"}
                     onClick={this.props.onClickExecute}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="silence" visible="never">
+                <ToolbarMenu.Item key="silence" visible="never">
                   <SilenceMenuItem
                     disabled={!!check.isSilenced}
                     onClick={this.props.onClickSilence}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="unsilence" visible="never">
+                <ToolbarMenu.Item key="unsilence" visible="never">
                   <UnsilenceMenuItem
                     disabled={!check.isSilenced}
                     onClick={this.props.onClickClearSilences}
                   />
                 </ToolbarMenu.Item>
                 {!check.publish ? (
-                  <ToolbarMenu.Item id="publish" visible="never">
+                  <ToolbarMenu.Item key="publish" visible="never">
                     <PublishMenuItem
                       description="Publish check"
                       onClick={() => this.props.onClickSetPublish(true)}
                     />
                   </ToolbarMenu.Item>
                 ) : (
-                  <ToolbarMenu.Item id="unpublish" visible="never">
+                  <ToolbarMenu.Item key="unpublish" visible="never">
                     <UnpublishMenuItem
                       delete
                       description="Unpublish check"
@@ -143,7 +143,7 @@ class CheckListItem extends React.Component {
                     />
                   </ToolbarMenu.Item>
                 )}
-                <ToolbarMenu.Item id="delete" visible="never">
+                <ToolbarMenu.Item key="delete" visible="never">
                   <ConfirmDelete onSubmit={this.props.onClickDelete}>
                     {dialog => <DeleteMenuItem onClick={dialog.open} />}
                   </ConfirmDelete>

--- a/src/lib/component/partial/ChecksList/ChecksListToolbar.js
+++ b/src/lib/component/partial/ChecksList/ChecksListToolbar.js
@@ -13,14 +13,16 @@ class ChecksListToolbar extends React.PureComponent {
     query: PropTypes.string,
     onChangeQuery: PropTypes.func.isRequired,
     onClickReset: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     query: "",
+    toolbarItems: ({ items }) => items,
   };
 
   render() {
-    const { onChangeQuery, onClickReset, query } = this.props;
+    const { onChangeQuery, onClickReset, query, toolbarItems } = this.props;
 
     return (
       <ListToolbar
@@ -31,14 +33,19 @@ class ChecksListToolbar extends React.PureComponent {
             onSearch={onChangeQuery}
           />
         }
-        toolbarItems={({ collapsed }) => (
+        toolbarItems={props => (
           <ToolbarMenu>
-            <ToolbarMenu.Item
-              id="reset"
-              visible={collapsed ? "never" : "if-room"}
-            >
-              <ResetMenuItem onClick={onClickReset} />
-            </ToolbarMenu.Item>
+            {toolbarItems({
+              ...props,
+              items: [
+                <ToolbarMenu.Item
+                  key="reset"
+                  visible={props.collapsed ? "never" : "if-room"}
+                >
+                  <ResetMenuItem onClick={onClickReset} />
+                </ToolbarMenu.Item>,
+              ],
+            })}
           </ToolbarMenu>
         )}
       />

--- a/src/lib/component/partial/EntitiesList/EntitiesListHeader.js
+++ b/src/lib/component/partial/EntitiesList/EntitiesListHeader.js
@@ -55,14 +55,14 @@ class EntitiesListHeader extends React.PureComponent {
 
     return (
       <ToolbarMenu>
-        <ToolbarMenu.Item id="filter-by-subscriptions" visible="if-room">
+        <ToolbarMenu.Item key="filter-by-subscriptions" visible="if-room">
           <SelectMenuItem title="Subscription" onChange={this.updateFilter}>
             {subs.map(v => (
               <ToolbarSelectOption key={v} value={v} />
             ))}
           </SelectMenuItem>
         </ToolbarMenu.Item>
-        <ToolbarMenu.Item id="sort" visible="always">
+        <ToolbarMenu.Item key="sort" visible="always">
           <ListSortSelector
             options={[{ label: "Name", value: "ID" }]}
             onChangeQuery={onChangeQuery}
@@ -84,7 +84,7 @@ class EntitiesListHeader extends React.PureComponent {
     return (
       <ToolbarMenu>
         <ToolbarMenu.Item
-          id="silence"
+          key="silence"
           visible={allSelectedSilenced ? "never" : "always"}
         >
           <SilenceMenuItem
@@ -95,7 +95,7 @@ class EntitiesListHeader extends React.PureComponent {
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item
-          id="unsilence"
+          key="unsilence"
           visible={allSelectedUnsilenced ? "never" : "if-room"}
         >
           <UnsilenceMenuItem
@@ -105,7 +105,7 @@ class EntitiesListHeader extends React.PureComponent {
           />
         </ToolbarMenu.Item>
 
-        <ToolbarMenu.Item id="delete" visible="never">
+        <ToolbarMenu.Item key="delete" visible="never">
           {menu => (
             <ConfirmDelete
               identifier={`${selectedCount} ${

--- a/src/lib/component/partial/EntitiesList/EntitiesListItem.js
+++ b/src/lib/component/partial/EntitiesList/EntitiesListItem.js
@@ -112,19 +112,19 @@ class EntitiesListItem extends React.PureComponent {
           >
             {() => (
               <ToolbarMenu>
-                <ToolbarMenu.Item id="silence" visible="never">
+                <ToolbarMenu.Item key="silence" visible="never">
                   <SilenceMenuItem
                     disabled={entity.isSilenced}
                     onClick={this.props.onClickSilence}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="unsilence" visible="never">
+                <ToolbarMenu.Item key="unsilence" visible="never">
                   <UnsilenceMenuItem
                     disabled={!entity.isSilenced}
                     onClick={this.props.onClickClearSilence}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="delete" visible="never">
+                <ToolbarMenu.Item key="delete" visible="never">
                   {menu => (
                     <ConfirmDelete
                       onSubmit={() => {

--- a/src/lib/component/partial/EntitiesList/EntitiesListToolbar.js
+++ b/src/lib/component/partial/EntitiesList/EntitiesListToolbar.js
@@ -13,14 +13,16 @@ class EntitiesListToolbar extends React.PureComponent {
     query: PropTypes.string,
     onChangeQuery: PropTypes.func.isRequired,
     onClickReset: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     query: "",
+    toolbarItems: ({ items }) => items,
   };
 
   render() {
-    const { onChangeQuery, onClickReset, query } = this.props;
+    const { onChangeQuery, onClickReset, query, toolbarItems } = this.props;
 
     return (
       <ListToolbar
@@ -31,14 +33,19 @@ class EntitiesListToolbar extends React.PureComponent {
             onSearch={onChangeQuery}
           />
         }
-        toolbarItems={({ collapsed }) => (
+        toolbarItems={props => (
           <ToolbarMenu>
-            <ToolbarMenu.Item
-              id="reset"
-              visible={collapsed ? "never" : "if-room"}
-            >
-              <ResetMenuItem onClick={onClickReset} />
-            </ToolbarMenu.Item>
+            {toolbarItems({
+              ...props,
+              items: [
+                <ToolbarMenu.Item
+                  key="reset"
+                  visible={props.collapsed ? "never" : "if-room"}
+                >
+                  <ResetMenuItem onClick={onClickReset} />
+                </ToolbarMenu.Item>,
+              ],
+            })}
           </ToolbarMenu>
         )}
       />

--- a/src/lib/component/partial/EntityDetailsContainer/EntityDetailsContainer.js
+++ b/src/lib/component/partial/EntityDetailsContainer/EntityDetailsContainer.js
@@ -16,6 +16,11 @@ class EntityDetailsContainer extends React.PureComponent {
   static propTypes = {
     entity: PropTypes.object.isRequired,
     refetch: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   static fragments = {
@@ -38,12 +43,16 @@ class EntityDetailsContainer extends React.PureComponent {
   };
 
   render() {
-    const { entity, refetch } = this.props;
+    const { entity, refetch, toolbarItems } = this.props;
 
     return (
       <React.Fragment>
         <Content marginBottom>
-          <EntityDetailsToolbar entity={entity} refetch={refetch} />
+          <EntityDetailsToolbar
+            toolbarItems={toolbarItems}
+            entity={entity}
+            refetch={refetch}
+          />
         </Content>
 
         <Grid container spacing={16}>

--- a/src/lib/component/partial/EntityDetailsContainer/EntityDetailsToolbar.js
+++ b/src/lib/component/partial/EntityDetailsContainer/EntityDetailsToolbar.js
@@ -19,6 +19,11 @@ class EntityDetailsToolbar extends React.Component {
   static propTypes = {
     entity: PropTypes.object.isRequired,
     refetch: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: ({ items }) => items,
   };
 
   static fragments = {
@@ -38,45 +43,47 @@ class EntityDetailsToolbar extends React.Component {
   };
 
   render() {
-    const { entity, refetch } = this.props;
+    const { entity, refetch, toolbarItems } = this.props;
 
     return (
       <Toolbar
         right={
           <ToolbarMenu>
-            <ToolbarMenu.Item
-              id="silence"
-              visible={entity.isSilenced ? "never" : "if-room"}
-            >
-              <SilenceAction entity={entity} onDone={refetch}>
-                {dialog => (
-                  <SilenceMenuItem
-                    disabled={dialog.canOpen}
-                    onClick={dialog.open}
-                  />
-                )}
-              </SilenceAction>
-            </ToolbarMenu.Item>
-
-            <ToolbarMenu.Item
-              id="unsilence"
-              visible={entity.isSilenced ? "if-room" : "never"}
-            >
-              <ClearSilenceAction record={entity} onDone={refetch}>
-                {dialog => (
-                  <UnsilenceMenuItem
-                    disabled={!dialog.canOpen}
-                    onClick={dialog.open}
-                  />
-                )}
-              </ClearSilenceAction>
-            </ToolbarMenu.Item>
-
-            <ToolbarMenu.Item id="delete" visible="never">
-              <DeleteAction entity={entity}>
-                {handler => <DeleteMenuItem onClick={handler} />}
-              </DeleteAction>
-            </ToolbarMenu.Item>
+            {toolbarItems({
+              items: [
+                <ToolbarMenu.Item
+                  key="silence"
+                  visible={entity.isSilenced ? "never" : "if-room"}
+                >
+                  <SilenceAction entity={entity} onDone={refetch}>
+                    {dialog => (
+                      <SilenceMenuItem
+                        disabled={dialog.canOpen}
+                        onClick={dialog.open}
+                      />
+                    )}
+                  </SilenceAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item
+                  key="unsilence"
+                  visible={entity.isSilenced ? "if-room" : "never"}
+                >
+                  <ClearSilenceAction record={entity} onDone={refetch}>
+                    {dialog => (
+                      <UnsilenceMenuItem
+                        disabled={!dialog.canOpen}
+                        onClick={dialog.open}
+                      />
+                    )}
+                  </ClearSilenceAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item key="delete" visible="never">
+                  <DeleteAction entity={entity}>
+                    {handler => <DeleteMenuItem onClick={handler} />}
+                  </DeleteAction>
+                </ToolbarMenu.Item>,
+              ],
+            })}
           </ToolbarMenu>
         }
       />

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsContent.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsContent.js
@@ -16,11 +16,13 @@ class EventDetailsContainer extends React.Component {
     event: PropTypes.object,
     loading: PropTypes.bool.isRequired,
     refetch: PropTypes.func,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     event: null,
     refetch: () => null,
+    toolbarItems: undefined,
   };
 
   static fragments = {
@@ -52,14 +54,18 @@ class EventDetailsContainer extends React.Component {
   };
 
   render() {
-    const { event, loading, refetch } = this.props;
+    const { event, loading, refetch, toolbarItems } = this.props;
 
     return (
       <Loader loading={loading} passthrough>
         {event && (
           <React.Fragment>
             <Content marginBottom>
-              <Toolbar event={event} refetch={refetch} />
+              <Toolbar
+                toolbarItems={toolbarItems}
+                event={event}
+                refetch={refetch}
+              />
             </Content>
             <Grid container spacing={16}>
               <Grid item xs={12}>

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsToolbar.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsToolbar.js
@@ -23,10 +23,12 @@ class EventDetailsToolbar extends React.Component {
   static propTypes = {
     event: PropTypes.object.isRequired,
     refetch: PropTypes.func,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     refetch: () => null,
+    toolbarItems: ({ items }) => items,
   };
 
   static fragments = {
@@ -49,58 +51,65 @@ class EventDetailsToolbar extends React.Component {
   };
 
   render() {
-    const { event, refetch } = this.props;
+    const { event, refetch, toolbarItems } = this.props;
 
     return (
       <Toolbar
         right={
           <ToolbarMenu fillWidth>
-            <ToolbarMenu.Item id="resolve" visible="always">
-              <ResolveAction event={event}>
-                {({ resolve, canResolve }) => (
-                  <ResolveMenuItem disabled={!canResolve} onClick={resolve} />
-                )}
-              </ResolveAction>
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item id="re-run" visible="if-room">
-              {event.check.name !== "keepalive" && (
-                <ReRunAction event={event}>
-                  {run => (
-                    <QueueExecutionMenuItem
-                      title="Re-run Check"
-                      titleCondensed="Re-run"
-                      onClick={run}
-                    />
+            {toolbarItems({
+              items: [
+                <ToolbarMenu.Item key="resolve" visible="always">
+                  <ResolveAction event={event}>
+                    {({ resolve, canResolve }) => (
+                      <ResolveMenuItem
+                        disabled={!canResolve}
+                        onClick={resolve}
+                      />
+                    )}
+                  </ResolveAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item key="re-run" visible="if-room">
+                  {event.check.name !== "keepalive" && (
+                    <ReRunAction event={event}>
+                      {run => (
+                        <QueueExecutionMenuItem
+                          title="Re-run Check"
+                          titleCondensed="Re-run"
+                          onClick={run}
+                        />
+                      )}
+                    </ReRunAction>
                   )}
-                </ReRunAction>
-              )}
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item
-              id="silence"
-              visible={event.isSilenced ? "never" : "if-room"}
-            >
-              <SilenceAction event={event} onDone={refetch}>
-                {menu => <SilenceMenuItem onClick={menu.open} />}
-              </SilenceAction>
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item
-              id="unsilence"
-              visible={event.isSilenced ? "if-room" : "never"}
-            >
-              <ClearSilenceAction record={event} onDone={refetch}>
-                {menu => (
-                  <UnsilenceMenuItem
-                    onClick={menu.open}
-                    disabled={!menu.canOpen}
-                  />
-                )}
-              </ClearSilenceAction>
-            </ToolbarMenu.Item>
-            <ToolbarMenu.Item id="delete" visible="never">
-              <DeleteAction event={event}>
-                {handler => <DeleteMenuItem onClick={handler} />}
-              </DeleteAction>
-            </ToolbarMenu.Item>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item
+                  key="silence"
+                  visible={event.isSilenced ? "never" : "if-room"}
+                >
+                  <SilenceAction event={event} onDone={refetch}>
+                    {menu => <SilenceMenuItem onClick={menu.open} />}
+                  </SilenceAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item
+                  key="unsilence"
+                  visible={event.isSilenced ? "if-room" : "never"}
+                >
+                  <ClearSilenceAction record={event} onDone={refetch}>
+                    {menu => (
+                      <UnsilenceMenuItem
+                        onClick={menu.open}
+                        disabled={!menu.canOpen}
+                      />
+                    )}
+                  </ClearSilenceAction>
+                </ToolbarMenu.Item>,
+                <ToolbarMenu.Item key="delete" visible="never">
+                  <DeleteAction event={event}>
+                    {handler => <DeleteMenuItem onClick={handler} />}
+                  </DeleteAction>
+                </ToolbarMenu.Item>,
+              ],
+            })}
           </ToolbarMenu>
         }
       />

--- a/src/lib/component/partial/EventsList/EventsListHeader.js
+++ b/src/lib/component/partial/EventsList/EventsListHeader.js
@@ -120,14 +120,14 @@ class EventsListHeader extends React.Component {
 
     return (
       <ToolbarMenu>
-        <ToolbarMenu.Item id="resolve" visible="always">
+        <ToolbarMenu.Item key="resolve" visible="always">
           <ResolveMenuItem
             description="Resolve selected event(s)."
             onClick={this.props.onClickResolve}
           />
         </ToolbarMenu.Item>
 
-        <ToolbarMenu.Item id="re-run" visible="if-room">
+        <ToolbarMenu.Item key="re-run" visible="if-room">
           <QueueExecutionMenuItem
             disabled={selectedNonKeepalives.length === 0}
             title="Re-run Checks"
@@ -138,7 +138,7 @@ class EventsListHeader extends React.Component {
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item
-          id="silence"
+          key="silence"
           visible={allSelectedSilenced ? "never" : "if-room"}
         >
           <SilenceMenuItem
@@ -148,7 +148,7 @@ class EventsListHeader extends React.Component {
         </ToolbarMenu.Item>
 
         <ToolbarMenu.Item
-          id="unsilence"
+          key="unsilence"
           visible={allSelectedUnsilenced ? "never" : "if-room"}
         >
           <UnsilenceMenuItem
@@ -157,7 +157,7 @@ class EventsListHeader extends React.Component {
           />
         </ToolbarMenu.Item>
 
-        <ToolbarMenu.Item id="delete" visible="never">
+        <ToolbarMenu.Item key="delete" visible="never">
           {menu => (
             <ConfirmDelete
               identifier={`${selectedCount} ${
@@ -191,14 +191,14 @@ class EventsListHeader extends React.Component {
       <ToolbarMenu.Autosizer>
         {({ width }) => (
           <ToolbarMenu width={width}>
-            <ToolbarMenu.Item id="hide" visible="if-room">
+            <ToolbarMenu.Item key="hide" visible="if-room">
               <Select title="Hide" onChange={this.requeryHide}>
                 <Option value="passing">Passing</Option>
                 <Option value="silenced">Silenced</Option>
               </Select>
             </ToolbarMenu.Item>
 
-            <ToolbarMenu.Item id="filter-by-entity" visible="if-room">
+            <ToolbarMenu.Item key="filter-by-entity" visible="if-room">
               <Select title="Entity" onChange={this.requeryEntity}>
                 {entities.map(name => (
                   <Option key={name} value={name} />
@@ -206,7 +206,7 @@ class EventsListHeader extends React.Component {
               </Select>
             </ToolbarMenu.Item>
 
-            <ToolbarMenu.Item id="filter-by-check" visible="if-room">
+            <ToolbarMenu.Item key="filter-by-check" visible="if-room">
               <Select title="Check" onChange={this.requeryCheck}>
                 {checks.map(name => (
                   <Option key={name} value={name} />
@@ -214,7 +214,7 @@ class EventsListHeader extends React.Component {
               </Select>
             </ToolbarMenu.Item>
 
-            <ToolbarMenu.Item id="filter-by-status" visible="always">
+            <ToolbarMenu.Item key="filter-by-status" visible="always">
               <SubmenuMenuItem
                 autoClose
                 title="Status"
@@ -231,7 +231,7 @@ class EventsListHeader extends React.Component {
               />
             </ToolbarMenu.Item>
 
-            <ToolbarMenu.Item id="sort" visible="always">
+            <ToolbarMenu.Item key="sort" visible="always">
               <Select title="Sort" onChange={this.updateSort}>
                 <Option value="LASTOK">Last OK</Option>
                 <Option value="SEVERITY">Severity</Option>

--- a/src/lib/component/partial/EventsList/EventsListItem.js
+++ b/src/lib/component/partial/EventsList/EventsListItem.js
@@ -131,20 +131,20 @@ class EventListItem extends React.Component {
           >
             {() => (
               <ToolbarMenu>
-                <ToolbarMenu.Item id="resolve" visible="always">
+                <ToolbarMenu.Item key="resolve" visible="always">
                   <ResolveMenuItem
                     iconOnly
                     disabled={event.status === 0}
                     onClick={this.props.onClickResolve}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="re-run" visible="never">
+                <ToolbarMenu.Item key="re-run" visible="never">
                   <QueueExecutionMenuItem
                     disabled={event.check.name === "keepalive"}
                     onClick={this.props.onClickRerun}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="silence" visible="never">
+                <ToolbarMenu.Item key="silence" visible="never">
                   <Select
                     disabled={event.isSilenced}
                     icon={<SilenceIcon />}
@@ -164,13 +164,13 @@ class EventListItem extends React.Component {
                     <Option value="both">Both</Option>
                   </Select>
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="unsilenced" visible="never">
+                <ToolbarMenu.Item key="unsilenced" visible="never">
                   <UnsilenceMenuItem
                     disabled={!event.isSilenced}
                     onClick={this.props.onClickClearSilences}
                   />
                 </ToolbarMenu.Item>
-                <ToolbarMenu.Item id="delete" visible="never">
+                <ToolbarMenu.Item key="delete" visible="never">
                   {menu => (
                     <ConfirmDelete
                       onSubmit={() => {

--- a/src/lib/component/partial/EventsList/EventsListToolbar.js
+++ b/src/lib/component/partial/EventsList/EventsListToolbar.js
@@ -13,10 +13,12 @@ class EventsListToolbar extends React.PureComponent {
     query: PropTypes.string,
     onChangeQuery: PropTypes.func.isRequired,
     onClickReset: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     query: "",
+    toolbarItems: ({ items }) => items,
   };
 
   reset = ev => {
@@ -24,7 +26,7 @@ class EventsListToolbar extends React.PureComponent {
   };
 
   render() {
-    const { onChangeQuery, query } = this.props;
+    const { onChangeQuery, query, toolbarItems } = this.props;
 
     return (
       <ListToolbar
@@ -35,14 +37,19 @@ class EventsListToolbar extends React.PureComponent {
             onSearch={onChangeQuery}
           />
         }
-        toolbarItems={({ collapsed }) => (
+        toolbarItems={props => (
           <ToolbarMenu>
-            <ToolbarMenu.Item
-              id="reset-query"
-              visible={collapsed ? "never" : "if-room"}
-            >
-              <ResetMenuItem onClick={this.reset} />
-            </ToolbarMenu.Item>
+            {toolbarItems({
+              ...props,
+              items: [
+                <ToolbarMenu.Item
+                  key="reset-query"
+                  visible={props.collapsed ? "never" : "if-room"}
+                >
+                  <ResetMenuItem onClick={this.reset} />
+                </ToolbarMenu.Item>,
+              ],
+            })}
           </ToolbarMenu>
         )}
       />

--- a/src/lib/component/partial/QuickNav/Nav.js
+++ b/src/lib/component/partial/QuickNav/Nav.js
@@ -20,7 +20,7 @@ class QuickNav extends React.Component {
         {links => (
           <div className={className}>
             {links.map(({ icon, caption, to }) => (
-              <Button Icon={icon} caption={caption} to={to} />
+              <Button key={to} Icon={icon} caption={caption} to={to} />
             ))}
           </div>
         )}

--- a/src/lib/component/partial/SilencesList/SilencesListHeader.js
+++ b/src/lib/component/partial/SilencesList/SilencesListHeader.js
@@ -28,7 +28,7 @@ class SilencesListHeader extends React.PureComponent {
 
     return (
       <ToolbarMenu>
-        <ToolbarMenu.Item id="sort" visible="always">
+        <ToolbarMenu.Item key="sort" visible="always">
           <ListSortSelector
             onChangeQuery={onChangeQuery}
             options={[
@@ -44,7 +44,7 @@ class SilencesListHeader extends React.PureComponent {
 
   renderBulkActions = () => (
     <ToolbarMenu>
-      <ToolbarMenu.Item id="clearSilence" visible="always">
+      <ToolbarMenu.Item key="clearSilence" visible="always">
         <UnsilenceMenuItem onClick={this.props.onClickClearSilences} />
       </ToolbarMenu.Item>
     </ToolbarMenu>

--- a/src/lib/component/partial/SilencesList/SilencesListItem.js
+++ b/src/lib/component/partial/SilencesList/SilencesListItem.js
@@ -175,7 +175,7 @@ class SilencesListItem extends React.Component {
                 )}
 
                 <ToolbarMenu>
-                  <ToolbarMenu.Item id="delete" visible="never">
+                  <ToolbarMenu.Item key="delete" visible="never">
                     <UnsilenceMenuItem
                       onClick={this.props.onClickClearSilences}
                     />

--- a/src/lib/component/partial/SilencesList/SilencesListToolbar.js
+++ b/src/lib/component/partial/SilencesList/SilencesListToolbar.js
@@ -17,13 +17,17 @@ class SilencesListToolbar extends React.Component {
     onChangeQuery: PropTypes.func.isRequired,
     onClickCreate: PropTypes.func.isRequired,
     onClickReset: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
   };
 
   static defaultProps = {
     filter: "",
+    toolbarItems: ({ items }) => items,
   };
 
   render() {
+    const { toolbarItems } = this.props;
+
     return (
       <ListToolbar
         search={
@@ -33,21 +37,32 @@ class SilencesListToolbar extends React.Component {
             onSearch={this.props.onChangeQuery}
           />
         }
-        toolbarItems={({ collapsed }) => {
+        toolbarItems={props => {
           const unlessCollapsed = visiblity =>
-            collapsed ? "never" : visiblity;
+            props.collapsed ? "never" : visiblity;
 
           return (
             <ToolbarMenu>
-              <ToolbarMenu.Item id="new" visible={unlessCollapsed("always")}>
-                <NewMenuItem
-                  title="New Silence…"
-                  onClick={this.props.onClickCreate}
-                />
-              </ToolbarMenu.Item>
-              <ToolbarMenu.Item id="reset" visible={unlessCollapsed("if-room")}>
-                <ResetMenuItem onClick={this.props.onClickReset} />
-              </ToolbarMenu.Item>
+              {toolbarItems({
+                ...props,
+                items: [
+                  <ToolbarMenu.Item
+                    key="new"
+                    visible={unlessCollapsed("always")}
+                  >
+                    <NewMenuItem
+                      title="New Silence…"
+                      onClick={this.props.onClickCreate}
+                    />
+                  </ToolbarMenu.Item>,
+                  <ToolbarMenu.Item
+                    key="reset"
+                    visible={unlessCollapsed("if-room")}
+                  >
+                    <ResetMenuItem onClick={this.props.onClickReset} />
+                  </ToolbarMenu.Item>,
+                ],
+              })}
             </ToolbarMenu>
           );
         }}

--- a/src/lib/component/partial/ToolbarMenu/Item.js
+++ b/src/lib/component/partial/ToolbarMenu/Item.js
@@ -8,13 +8,13 @@ class Item extends React.PureComponent {
   static displayName = "ToolbarMenu.Item";
 
   static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-    id: PropTypes.string.isRequired, // eslint-disable-line react/no-unused-prop-types
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     onResize: PropTypes.func,
     visible: PropTypes.oneOf(["if-room", "always", "never"]), // eslint-disable-line react/no-unused-prop-types
   };
 
   static defaultProps = {
+    children: undefined,
     onResize: null,
     visible: "if-room",
   };

--- a/src/lib/component/partial/ToolbarMenu/ToolbarMenu.js
+++ b/src/lib/component/partial/ToolbarMenu/ToolbarMenu.js
@@ -36,29 +36,30 @@ class ToolbarMenu extends React.PureComponent {
 
   static Item = MenuItem;
 
-  // If the menu items change poison the buttons container's width, to ensure
+  // If the menu items change position the buttons container's width, to ensure
   // that we are displaying as many buttons as possible.
   static getDerivedStateFromProps(props, state) {
-    const ids = React.Children.map(props.children, child => child.props.id);
+    const keys = React.Children.map(props.children, child => child.key);
     const visibility = React.Children.map(
       props.children,
       child => child.props.visible,
     );
+
     if (
       // if we add more props that this equation depends on
       // we should really just rewrite shallowEqual and send these
       // in a single array, but for now, it's fine
-      !shallowEqual(ids, state.ids) ||
+      !shallowEqual(keys, state.keys) ||
       !shallowEqual(visibility, state.visibility)
     ) {
-      return { ids, visibility, buttonsWidth: null };
+      return { keys, visibility, buttonsWidth: null };
     }
     return null;
   }
 
   state = {
-    // List of item ids
-    ids: [],
+    // List of child react keys
+    keys: [],
     visibility: [],
 
     // Width of buttons container
@@ -201,4 +202,4 @@ class ToolbarMenu extends React.PureComponent {
   }
 }
 
-export { Context, ToolbarMenu as default };
+export default ToolbarMenu;

--- a/src/lib/component/partial/ToolbarMenu/index.js
+++ b/src/lib/component/partial/ToolbarMenu/index.js
@@ -1,3 +1,4 @@
-export { default, Context as ToolbarMenuContext } from "./Menu";
+export { default } from "./ToolbarMenu";
+export { default as ToolbarMenuContext } from "./context";
 export { default as ToolbarMenuPartitioner } from "./Partitioner";
 export { default as ToolbarMenuAutosizer } from "./Autosizer";

--- a/src/lib/component/view/CheckDetailsView.js
+++ b/src/lib/component/view/CheckDetailsView.js
@@ -27,9 +27,16 @@ const query = gql`
 class CheckDetailsContent extends React.PureComponent {
   static propTypes = {
     match: PropTypes.object.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   render() {
+    const { toolbarItems } = this.props;
+
     return (
       <AppLayout namespace={this.props.match.params.namespace}>
         <Query
@@ -61,6 +68,7 @@ class CheckDetailsContent extends React.PureComponent {
 
             return (
               <CheckDetailsContainer
+                toolbarItems={toolbarItems}
                 client={client}
                 check={check}
                 loading={loading || aborted}

--- a/src/lib/component/view/ChecksView.js
+++ b/src/lib/component/view/ChecksView.js
@@ -23,6 +23,11 @@ class ChecksView extends React.Component {
       limit: PropTypes.string,
     }).isRequired,
     setQueryParams: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   static query = gql`
@@ -42,7 +47,7 @@ class ChecksView extends React.Component {
   `;
 
   render() {
-    const { match, queryParams, setQueryParams } = this.props;
+    const { match, queryParams, setQueryParams, toolbarItems } = this.props;
     const { limit, offset, filter } = queryParams;
     const variables = { ...match.params, ...queryParams };
 
@@ -73,6 +78,7 @@ class ChecksView extends React.Component {
               <div>
                 <Content marginBottom>
                   <ChecksListToolbar
+                    toolbarItems={toolbarItems}
                     query={filter}
                     onChangeQuery={value => setQueryParams({ filter: value })}
                     onClickReset={() =>

--- a/src/lib/component/view/EntitiesView.js
+++ b/src/lib/component/view/EntitiesView.js
@@ -25,6 +25,11 @@ class EntitiesView extends React.PureComponent {
       limit: PropTypes.string,
     }).isRequired,
     setQueryParams: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   static query = gql`
@@ -44,7 +49,7 @@ class EntitiesView extends React.PureComponent {
   `;
 
   render() {
-    const { queryParams, match, setQueryParams } = this.props;
+    const { queryParams, match, setQueryParams, toolbarItems } = this.props;
     const { filter, limit, offset, order } = queryParams;
     const variables = { ...match.params, ...queryParams };
 
@@ -75,6 +80,7 @@ class EntitiesView extends React.PureComponent {
               <div>
                 <Content marginBottom>
                   <EntitiesListToolbar
+                    toolbarItems={toolbarItems}
                     onChangeQuery={value => setQueryParams({ filter: value })}
                     onClickReset={() => setQueryParams(q => q.reset())}
                     query={filter}

--- a/src/lib/component/view/EntityDetailsView.js
+++ b/src/lib/component/view/EntityDetailsView.js
@@ -27,9 +27,15 @@ const query = gql`
 class EntityDetailsView extends React.PureComponent {
   static propTypes = {
     match: PropTypes.object.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   render() {
+    const { toolbarItems } = this.props;
     return (
       <AppLayout namespace={this.props.match.params.namespace}>
         <Query
@@ -56,7 +62,11 @@ class EntityDetailsView extends React.PureComponent {
             return (
               <Loader loading={loading || aborted} passthrough>
                 {entity && (
-                  <EntityDetailsContainer entity={entity} refetch={refetch} />
+                  <EntityDetailsContainer
+                    toolbarItems={toolbarItems}
+                    entity={entity}
+                    refetch={refetch}
+                  />
                 )}
               </Loader>
             );

--- a/src/lib/component/view/EventDetailsView.js
+++ b/src/lib/component/view/EventDetailsView.js
@@ -32,9 +32,15 @@ const query = gql`
 class EventDetailsView extends React.PureComponent {
   static propTypes = {
     match: PropTypes.object.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   render() {
+    const { toolbarItems } = this.props;
     return (
       <AppLayout namespace={this.props.match.params.namespace}>
         <Query
@@ -60,6 +66,7 @@ class EventDetailsView extends React.PureComponent {
 
             return (
               <EventDetailsContainer
+                toolbarItems={toolbarItems}
                 event={event}
                 loading={loading || !!aborted}
                 refetch={refetch}

--- a/src/lib/component/view/EventsView.js
+++ b/src/lib/component/view/EventsView.js
@@ -33,6 +33,11 @@ class EventsView extends React.Component {
 
     // from withQueryParams HOC
     setQueryParams: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   static query = gql`
@@ -52,7 +57,7 @@ class EventsView extends React.Component {
   `;
 
   render() {
-    const { queryParams, match, setQueryParams } = this.props;
+    const { queryParams, match, setQueryParams, toolbarItems } = this.props;
     const { filter, limit, offset } = queryParams;
     const variables = { ...match.params, ...queryParams };
 
@@ -83,6 +88,7 @@ class EventsView extends React.Component {
               <div>
                 <Content marginBottom>
                   <EventsListToolbar
+                    toolbarItems={toolbarItems}
                     onChangeQuery={value => setQueryParams({ filter: value })}
                     onClickReset={() =>
                       setQueryParams(q => q.reset(["filter", "order"]))

--- a/src/lib/component/view/SilencesView.js
+++ b/src/lib/component/view/SilencesView.js
@@ -36,6 +36,11 @@ class SilencesView extends React.Component {
       limit: PropTypes.string,
     }).isRequired,
     setQueryParams: PropTypes.func.isRequired,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarItems: undefined,
   };
 
   static query = gql`
@@ -55,7 +60,7 @@ class SilencesView extends React.Component {
   `;
 
   render() {
-    const { match, queryParams, setQueryParams } = this.props;
+    const { match, queryParams, setQueryParams, toolbarItems } = this.props;
     const { filter, limit, offset, order } = queryParams;
     const variables = { ...match.params, ...queryParams };
 
@@ -89,6 +94,7 @@ class SilencesView extends React.Component {
                     <React.Fragment>
                       <Content marginBottom>
                         <SilencesListToolbar
+                          toolbarItems={toolbarItems}
                           filter={filter}
                           onChangeQuery={val => setQueryParams({ filter: val })}
                           onClickCreate={newDialog.open}


### PR DESCRIPTION
Closes #48

The `toolbarItems` prop, with the signature `({items: React.ReactElement<ToolbarMenu.Item>[], collapsed?: boolean, width?: number }) => React.ReactElement<ToolbarMenu.Item>[]`, allows the consumer of any of the main view components to inject additional toolbar menu items when the view is rendered.

Example customization:

```jsx
import {ChecksView as BaseChecksView} from '/lib/component/view';

export default class ChecksView {
  state = {
    modalOpen: false,
  };

  render() {
    return (
      <React.Fragment>
        <ChecksView
          {...this.props}
          toolbarItems={({items}) => [
            ...items,
            <ToolbarMenu.Item key="example">
              <button
                onClick={() =>
                  this.setState({modalOpen: true})
                }
              >
                ...
              </button>
            </ToolbarMenu.Item>,
          ]}
        />
        {this.state.modalOpen && <ExampleModal/>}
      </React.Fragment>
    );
  }
}
```