### PR TITLE
Remove deprecated react-tap-event-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.0",
     "react-spring": "^5.6.10",
-    "react-tap-event-plugin": "^3.0.2",
     "recompose": "^0.30.0",
     "regenerator-runtime": "^0.11.1",
     "semver": "^5.6.0",

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -8,7 +8,6 @@ import {
   Route,
   Redirect,
 } from "/vendor/react-router-dom";
-import injectTapEventPlugin from "react-tap-event-plugin";
 
 // eslint-disable-next-line import/extensions
 import "typeface-roboto";
@@ -145,6 +144,3 @@ const renderApp = () => {
 polyfill()
   .then(updateServiceWorker)
   .then(renderApp);
-
-// Register React Tap event plugin
-injectTapEventPlugin();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,19 +3746,6 @@ fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fbjs@^0.8.6:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  integrity sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 fbjs@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
@@ -7467,13 +7454,6 @@ react-spring@^5.6.10:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-react-tap-event-plugin@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-3.0.2.tgz#280371677b881c31376e0027a0b86d2c6de039ee"
-  integrity sha1-KANxZ3uIHDE3bgAnoLhtLG3gOe4=
-  dependencies:
-    fbjs "^0.8.6"
-
 react-test-renderer@^16.0.0-0:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.3.tgz#5f3a1a7d5c3379d46f7052b848b4b72e47c89f38"
@@ -8745,11 +8725,6 @@ ua-parser-js@^0.7.18:
   version "0.7.19"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
   integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
-
-ua-parser-js@^0.7.9:
-  version "0.7.18"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
-  integrity sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Tap event plugin is deprecated and no longer supported.

see: https://github.com/zilverline/react-tap-event-plugin#deprecated