### PR TITLE
Show correct checkbox state for empty list

### DIFF
--- a/src/lib/component/partial/ListHeader/ListHeader.js
+++ b/src/lib/component/partial/ListHeader/ListHeader.js
@@ -68,7 +68,7 @@ class ListHeader extends React.Component {
         <Checkbox
           component="button"
           onClick={onClickSelect}
-          checked={selectedCount === rowCount}
+          checked={rowCount > 0 && selectedCount === rowCount}
           indeterminate={selectedCount > 0 && selectedCount !== rowCount}
           style={{ color: "inherit" }}
         />


### PR DESCRIPTION
Prevent the `ListHeader` component select-all checkbox from appearing as checked when the list is empty.

Before:
![image](https://user-images.githubusercontent.com/1074748/56686322-969d7e00-6688-11e9-9b44-1499319db219.png)

After:
![image](https://user-images.githubusercontent.com/1074748/56686290-85ed0800-6688-11e9-9d36-077d2714104e.png)
