### PR TITLE
Include id field when checks, entities and events

### DIFF
--- a/src/lib/component/view/CheckDetailsView.js
+++ b/src/lib/component/view/CheckDetailsView.js
@@ -17,6 +17,7 @@ import {
 const query = gql`
   query CheckDetailsContentQuery($namespace: String!, $check: String!) {
     check(namespace: $namespace, name: $check) {
+      id
       ...CheckDetailsContainer_check
     }
   }

--- a/src/lib/component/view/EntityDetailsView.js
+++ b/src/lib/component/view/EntityDetailsView.js
@@ -16,6 +16,7 @@ import {
 const query = gql`
   query EntityDetailsViewQuery($namespace: String!, $entity: String!) {
     entity(namespace: $namespace, name: $entity) {
+      id
       deleted @client
       ...EntityDetailsContainer_entity
     }

--- a/src/lib/component/view/EventDetailsView.js
+++ b/src/lib/component/view/EventDetailsView.js
@@ -21,6 +21,7 @@ const query = gql`
     $entity: String!
   ) {
     event(namespace: $namespace, entity: $entity, check: $check) {
+      id
       deleted @client
       ...EventDetailsContainer_event
     }


### PR DESCRIPTION
Avoids the following error by ensuring the ID is present for the cache to reference.

> "Invariant Violation: Store error" the application attempted to write an object
> with no provided id but the store already contains an id of
> srn:entities:sensu-devel:... this object. The selectionSet that was
> trying to be written ...

* [Apollo Source](https://github.com/apollographql/apollo-client/blob/26c4ff31c6e0853fe93094ca83e502fa0eef580c/packages/apollo-cache-inmemory/src/writeToStore.ts#L359-L371)
* [Related Feature Request](https://github.com/apollographql/apollo-feature-requests/issues/23)

Signed-off-by: James Phillips <jamesdphillips@gmail.com>