### PR TITLE
[Web] Touch up banner issues

### DIFF
--- a/src/lib/component/base/Banner.js
+++ b/src/lib/component/base/Banner.js
@@ -6,16 +6,19 @@ import { emphasize } from "/vendor/@material-ui/core/styles/colorManipulator";
 
 import {
   withStyles,
+  colors,
+  Paper,
+  Typography,
+} from "/vendor/@material-ui/core";
+
+import {
   CheckCircleIcon,
   ErrorIcon,
   InfoIcon,
   CloseIcon,
-  colors,
   IconButton,
   WarningIcon,
-  Paper,
-  Typography,
-} from "/vendor/@material-ui/core";
+} from "/lib/component/icon";
 
 import uniqueId from "/lib/util/uniqueId";
 import { Timer } from "/lib/component/util";
@@ -73,6 +76,8 @@ export const styles = theme => {
     },
 
     message: {
+      color: theme.palette.getContrastText(backgroundColor),
+
       paddingTop: 14,
       paddingBottom: 14,
 
@@ -213,8 +218,7 @@ class Banner extends React.PureComponent {
 
     return (
       <Paper
-        component={Typography}
-        headlineMapping={{
+        headlinemapping={{
           body1: "div",
         }}
         role="alertdialog"
@@ -226,10 +230,10 @@ class Banner extends React.PureComponent {
         onMouseLeave={this._handleMouseLeave}
       >
         <div className={classes.content}>
-          <div id={messageId} className={classes.message}>
+          <Typography id={messageId} className={classes.message}>
             {Icon && <Icon className={classes.variantIcon} />}
             {message}
-          </div>
+          </Typography>
           <div className={classes.action}>
             {actions}
             {!!maxAge && closeButton && (

--- a/src/lib/component/base/Banner.js
+++ b/src/lib/component/base/Banner.js
@@ -9,6 +9,7 @@ import {
   colors,
   Paper,
   Typography,
+  IconButton,
 } from "/vendor/@material-ui/core";
 
 import {
@@ -16,7 +17,6 @@ import {
   ErrorIcon,
   InfoIcon,
   CloseIcon,
-  IconButton,
   WarningIcon,
 } from "/lib/component/icon";
 


### PR DESCRIPTION
The alert banner was importing some icons incorrectly, causing them to not display. It was also causing some console errors which took some scrolling to get past.

Before:
<img width="1283" alt="Screen Shot 2019-05-02 at 12 35 29 PM" src="https://user-images.githubusercontent.com/1707663/57101872-09d17080-6cd7-11e9-812e-d5abc0e8c017.png">

After:
<img width="1284" alt="Screen Shot 2019-05-02 at 12 34 57 PM" src="https://user-images.githubusercontent.com/1707663/57101881-0e962480-6cd7-11e9-9a0e-cffac0337085.png">
