### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -41,4 +41,5 @@ labels: web-ui
 * Sensu version used (sensuctl, sensu-backend, and/or sensu-agent):
 * Installation method (packages, binaries, docker etc.):
 * Operating System and version (e.g. Ubuntu 14.04):
+* Browser used
 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,44 @@
+---
+labels: web-ui
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're looking for help, please see https://sensuapp.org/support for resources --->
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas as to the implementation of the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code or configuration to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context (e.g. links to configuration settings, stack strace or log data) helps us come up with a solution that is most useful in the real world -->
+
+## Customers
+<!--- A list of the customers affected or requesting, with links for context -->
+1.
+2.
+3.
+4.
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Sensu version used (sensuctl, sensu-backend, and/or sensu-agent):
+* Installation method (packages, binaries, docker etc.):
+* Operating System and version (e.g. Ubuntu 14.04):
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+---
+labels: web-ui
+---
+
+What is this change?
+
+<!-- A brief one-sentence-ish description of the change. -->
+
+
+## Why is this change necessary?
+
+<!-- A brief description of why the change of behavior is necessary. -->
+
+## Does your change need a Changelog entry?
+
+<!--
+Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
+-->
+
+## Do you need clarification on anything?
+
+<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->
+
+
+## Were there any complications while making this change?
+
+<!--
+If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:
+
+- refactoring was required
+- interfaces were unclear
+- it was difficult to get the information you needed to complete the issue
+
+Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
+-->
+
+## Have you reviewed and updated the documentation for this change? Is new documentation required?
+
+<!--
+Read any documentation that relates to the change you're making. If it needs
+updating, update it and file a PR. The PR should be linked to this PR
+or the original issue.
+-->
+
+## How did you verify this change?
+
+<!--
+Aside from unit/integration tests, please describe the e2e steps to verify this change.
+
+Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
+The corresponding sensu-go-qa-crucible PR or issue should be linked here.
+-->
+


### PR DESCRIPTION
Adds a PR and an issue template. This also (apparently) auto-assigns the web-ui label to all issues and PRs, making it easier to filter the web ui issues in zenhub. 

Followed the example from sensu-enterprise-go repo.