### PR TITLE
Display errors in status toasts

### DIFF
--- a/src/lib/component/base/Toast.js
+++ b/src/lib/component/base/Toast.js
@@ -45,7 +45,7 @@ export const styles = theme => {
       color: theme.palette.getContrastText(backgroundColor),
       backgroundColor,
       display: "flex",
-      alignItems: "center",
+      alignItems: "flex-start",
       [theme.breakpoints.up("md")]: {
         width: 400,
         borderRadius: theme.shape.borderRadius,
@@ -68,7 +68,7 @@ export const styles = theme => {
       paddingLeft: 24,
 
       display: "flex",
-      alignItems: "center",
+      alignItems: "flex-start",
 
       [theme.breakpoints.down("md")]: {
         marginLeft: "env(safe-area-inset-left)",

--- a/src/lib/component/partial/CheckDetailsContainer/CheckDetailsExecuteAction.js
+++ b/src/lib/component/partial/CheckDetailsContainer/CheckDetailsExecuteAction.js
@@ -1,5 +1,3 @@
-import React from "/vendor/react";
-import PropTypes from "prop-types";
 import gql from "/vendor/graphql-tag";
 import { withRouter } from "/vendor/react-router-dom";
 import { withApollo } from "/vendor/react-apollo";
@@ -8,52 +6,32 @@ import compose from "/lib/util/compose";
 
 import executeCheck from "/lib/mutation/executeCheck";
 
-import { ToastConnector } from "/lib/component/relocation";
+import { useExecuteCheckStatusToast } from "/lib/component/toast";
 
-import { ExecuteCheckStatusToast } from "/lib/component/toast";
+const CheckDetailsExecuteAction = ({ children, client, check }) => {
+  const createExecuteCheckStatusToast = useExecuteCheckStatusToast();
 
-class CheckDetailsExecuteAction extends React.PureComponent {
-  static propTypes = {
-    children: PropTypes.func.isRequired,
-    client: PropTypes.object.isRequired,
-    check: PropTypes.object.isRequired,
-  };
+  return children(() => {
+    const promise = executeCheck(client, {
+      id: check.id,
+    });
 
-  static fragments = {
-    check: gql`
-      fragment CheckDetailsExecuteAction_check on CheckConfig {
-        id
-        name
-        namespace
-      }
-    `,
-  };
+    createExecuteCheckStatusToast(promise, {
+      checkName: check.name,
+      namespace: check.namespace,
+    });
+  });
+};
 
-  render() {
-    const { children, client, check } = this.props;
-
-    return (
-      <ToastConnector>
-        {({ setToast }) =>
-          children(() => {
-            const promise = executeCheck(client, {
-              id: check.id,
-            });
-
-            setToast(undefined, ({ remove }) => (
-              <ExecuteCheckStatusToast
-                onClose={remove}
-                mutation={promise}
-                checkName={check.name}
-                namespace={check.namespace}
-              />
-            ));
-          })
-        }
-      </ToastConnector>
-    );
-  }
-}
+CheckDetailsExecuteAction.fragments = {
+  check: gql`
+    fragment CheckDetailsExecuteAction_check on CheckConfig {
+      id
+      name
+      namespace
+    }
+  `,
+};
 
 const enhancer = compose(
   withApollo,

--- a/src/lib/component/partial/CheckDetailsContainer/CheckDetailsPublishAction.js
+++ b/src/lib/component/partial/CheckDetailsContainer/CheckDetailsPublishAction.js
@@ -1,54 +1,40 @@
-import React from "/vendor/react";
 import PropTypes from "prop-types";
 import gql from "/vendor/graphql-tag";
 import { withApollo } from "/vendor/react-apollo";
 
 import setCheckPublish from "/lib/mutation/setCheckPublish";
 
-import { ToastConnector } from "/lib/component/relocation";
+import { usePublishCheckStatusToast } from "/lib/component/toast";
 
-import { PublishCheckStatusToast } from "/lib/component/toast";
+const CheckDetailsPublishAction = ({ children, client, check }) => {
+  const createPublishCheckStatusToast = usePublishCheckStatusToast();
 
-class CheckDetailsPublishAction extends React.PureComponent {
-  static propTypes = {
-    children: PropTypes.func.isRequired,
-    client: PropTypes.object.isRequired,
-    check: PropTypes.object.isRequired,
-  };
+  return children(() => {
+    const promise = setCheckPublish(client, {
+      id: check.id,
+      publish: true,
+    });
 
-  static fragments = {
-    check: gql`
-      fragment CheckDetailsPublishAction_check on CheckConfig {
-        id
-        name
-        publish
-      }
-    `,
-  };
+    createPublishCheckStatusToast(promise, {
+      checkName: check.name,
+    });
+  });
+};
 
-  render() {
-    const { children, client, check } = this.props;
+CheckDetailsPublishAction.propTypes = {
+  children: PropTypes.func.isRequired,
+  client: PropTypes.object.isRequired,
+  check: PropTypes.object.isRequired,
+};
 
-    return (
-      <ToastConnector>
-        {({ setToast }) =>
-          children(() => {
-            const promise = setCheckPublish(client, {
-              id: check.id,
-              publish: true,
-            });
-            setToast(undefined, ({ remove }) => (
-              <PublishCheckStatusToast
-                onClose={remove}
-                mutation={promise}
-                checkName={check.name}
-              />
-            ));
-          })
-        }
-      </ToastConnector>
-    );
-  }
-}
+CheckDetailsPublishAction.fragments = {
+  check: gql`
+    fragment CheckDetailsPublishAction_check on CheckConfig {
+      id
+      name
+      publish
+    }
+  `,
+};
 
 export default withApollo(CheckDetailsPublishAction);

--- a/src/lib/component/partial/CheckDetailsContainer/CheckDetailsUnpublishAction.js
+++ b/src/lib/component/partial/CheckDetailsContainer/CheckDetailsUnpublishAction.js
@@ -1,55 +1,41 @@
-import React from "/vendor/react";
 import PropTypes from "prop-types";
 import gql from "/vendor/graphql-tag";
 import { withApollo } from "/vendor/react-apollo";
 
 import setCheckPublish from "/lib/mutation/setCheckPublish";
 
-import { ToastConnector } from "/lib/component/relocation";
+import { usePublishCheckStatusToast } from "/lib/component/toast";
 
-import { PublishCheckStatusToast } from "/lib/component/toast";
+const CheckDetailsUnpublishAction = ({ children, client, check }) => {
+  const createPublishCheckStatusToast = usePublishCheckStatusToast();
 
-class CheckDetailsUnpublishAction extends React.PureComponent {
-  static propTypes = {
-    children: PropTypes.func.isRequired,
-    client: PropTypes.object.isRequired,
-    check: PropTypes.object.isRequired,
-  };
+  return children(() => {
+    const promise = setCheckPublish(client, {
+      id: check.id,
+      publish: false,
+    });
 
-  static fragments = {
-    check: gql`
-      fragment CheckDetailsPublishAction_check on CheckConfig {
-        id
-        name
-        publish
-      }
-    `,
-  };
+    createPublishCheckStatusToast(promise, {
+      checkName: check.name,
+      publish: false,
+    });
+  });
+};
 
-  render() {
-    const { children, client, check } = this.props;
+CheckDetailsUnpublishAction.propTypes = {
+  children: PropTypes.func.isRequired,
+  client: PropTypes.object.isRequired,
+  check: PropTypes.object.isRequired,
+};
 
-    return (
-      <ToastConnector>
-        {({ setToast }) =>
-          children(() => {
-            const promise = setCheckPublish(client, {
-              id: check.id,
-              publish: false,
-            });
-            setToast(undefined, ({ remove }) => (
-              <PublishCheckStatusToast
-                onClose={remove}
-                mutation={promise}
-                checkName={check.name}
-                publish={false}
-              />
-            ));
-          })
-        }
-      </ToastConnector>
-    );
-  }
-}
+CheckDetailsUnpublishAction.fragments = {
+  check: gql`
+    fragment CheckDetailsPublishAction_check on CheckConfig {
+      id
+      name
+      publish
+    }
+  `,
+};
 
 export default withApollo(CheckDetailsUnpublishAction);

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsReRunAction.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsReRunAction.js
@@ -1,5 +1,3 @@
-import React from "/vendor/react";
-import PropTypes from "prop-types";
 import gql from "/vendor/graphql-tag";
 import { withRouter } from "/vendor/react-router-dom";
 import { withApollo } from "/vendor/react-apollo";
@@ -8,65 +6,45 @@ import compose from "/lib/util/compose";
 
 import executeCheck from "/lib/mutation/executeCheck";
 
-import { ToastConnector } from "/lib/component/relocation";
+import { useExecuteCheckStatusToast } from "/lib/component/toast";
 
-import { ExecuteCheckStatusToast } from "/lib/component/toast";
-
-class EventDetailsReRunAction extends React.PureComponent {
-  static propTypes = {
-    children: PropTypes.func.isRequired,
-    client: PropTypes.object.isRequired,
-    event: PropTypes.object.isRequired,
-  };
-
-  static fragments = {
-    event: gql`
-      fragment EventDetailsReRunAction_event on Event {
-        check {
-          nodeId
-          proxyEntityName
-        }
-        entity {
-          name
-        }
-        namespace
-      }
-    `,
-  };
-
-  render() {
-    const { children, event, client } = this.props;
-
-    // Unless this is a proxy entity target the specific entity
-    let subscriptions = [`entity:${event.entity.name}`];
-    if (event.check.proxyEntityName === event.entity.name) {
-      subscriptions = [];
-    }
-
-    return (
-      <ToastConnector>
-        {({ setToast }) =>
-          children(() => {
-            const promise = executeCheck(client, {
-              id: event.check.nodeId,
-              subscriptions,
-            });
-
-            setToast(undefined, ({ remove }) => (
-              <ExecuteCheckStatusToast
-                onClose={remove}
-                mutation={promise}
-                checkName={event.check.name}
-                entityName={event.entity.name}
-                namespace={event.namespace}
-              />
-            ));
-          })
-        }
-      </ToastConnector>
-    );
+const EventDetailsReRunAction = ({ children, event, client }) => {
+  // Unless this is a proxy entity target the specific entity
+  let subscriptions = [`entity:${event.entity.name}`];
+  if (event.check.proxyEntityName === event.entity.name) {
+    subscriptions = [];
   }
-}
+
+  const createExecuteCheckStatusToast = useExecuteCheckStatusToast();
+
+  return children(() => {
+    const promise = executeCheck(client, {
+      id: event.check.nodeId,
+      subscriptions,
+    });
+
+    createExecuteCheckStatusToast(promise, {
+      checkName: event.check.name,
+      entityName: event.entity.name,
+      namespace: event.namespace,
+    });
+  });
+};
+
+EventDetailsReRunAction.fragments = {
+  event: gql`
+    fragment EventDetailsReRunAction_event on Event {
+      check {
+        nodeId
+        proxyEntityName
+      }
+      entity {
+        name
+      }
+      namespace
+    }
+  `,
+};
 
 const enhancer = compose(
   withApollo,

--- a/src/lib/component/relocation/index.js
+++ b/src/lib/component/relocation/index.js
@@ -1,4 +1,8 @@
-export { default as useBanner, BannerConnector } from "./useBanner";
+export {
+  default as useBanner,
+  usePromiseBoundBanner,
+  BannerConnector,
+} from "./useBanner";
 export { default as BannerSink } from "./BannerSink";
 export { default as BannerWell } from "./BannerWell";
 export {
@@ -10,7 +14,11 @@ export {
   useWell,
   useRelocation,
 } from "./Relocation";
-export { default as useToast, ToastConnector } from "./useToast";
+export {
+  default as useToast,
+  usePromiseBoundToast,
+  ToastConnector,
+} from "./useToast";
 export { default as ToastSink } from "./ToastSink";
 export { default as ToastWell } from "./ToastWell";
 export { TOAST, BANNER } from "./types";

--- a/src/lib/component/relocation/useBanner.js
+++ b/src/lib/component/relocation/useBanner.js
@@ -2,6 +2,7 @@ import React from "/vendor/react";
 
 import { useRelocation } from "/lib/component/relocation/Relocation";
 import { BANNER } from "/lib/component/relocation/types";
+import usePromiseBoundComponent from "/lib/component/relocation/usePromiseBoundComponent";
 
 const useBanner = () => {
   const { setChild } = useRelocation();
@@ -9,6 +10,22 @@ const useBanner = () => {
     render => setChild(undefined, { render, type: BANNER }),
     [setChild],
   );
+};
+
+export const usePromiseBoundBanner = () => {
+  const update = usePromiseBoundComponent();
+
+  return (promise, render, handleError) => {
+    update(
+      promise,
+      ({ resolved, rejected, result, error }) => ({
+        type: BANNER,
+        render: ({ remove }) =>
+          render({ remove, resolved, rejected, result, error }),
+      }),
+      handleError,
+    );
+  };
 };
 
 export const BannerConnector = ({ children }) => {

--- a/src/lib/component/relocation/usePromiseBoundComponent.js
+++ b/src/lib/component/relocation/usePromiseBoundComponent.js
@@ -1,0 +1,51 @@
+import React from "react";
+
+import { useRelocation } from "./Relocation";
+
+const usePromiseBoundComponent = () => {
+  const { setChild } = useRelocation();
+
+  const idMap = React.useState(() => new WeakMap())[0];
+
+  return (promise, update, handleError = error => Promise.reject(error)) => {
+    promise.then(
+      result => {
+        setChild(
+          idMap.get(promise),
+          update({
+            resolved: true,
+            rejected: false,
+            result,
+            error: undefined,
+          }),
+        );
+      },
+      rawError => {
+        const error = handleError(rawError);
+        setChild(
+          idMap.get(promise),
+          update({
+            resolved: false,
+            rejected: true,
+            result: undefined,
+            error,
+          }),
+        );
+      },
+    );
+
+    const id = setChild(
+      idMap.get(promise),
+      update({
+        resolved: false,
+        rejected: false,
+        result: undefined,
+        error: undefined,
+      }),
+    );
+
+    idMap.set(promise, id);
+  };
+};
+
+export default usePromiseBoundComponent;

--- a/src/lib/component/relocation/useToast.js
+++ b/src/lib/component/relocation/useToast.js
@@ -2,6 +2,7 @@ import React from "/vendor/react";
 
 import { useRelocation } from "/lib/component/relocation/Relocation";
 import { TOAST } from "/lib/component/relocation/types";
+import usePromiseBoundComponent from "/lib/component/relocation/usePromiseBoundComponent";
 
 const useToast = () => {
   const { setChild } = useRelocation();
@@ -9,6 +10,22 @@ const useToast = () => {
     (id, render) => setChild(id, { render, type: TOAST }),
     [setChild],
   );
+};
+
+export const usePromiseBoundToast = () => {
+  const update = usePromiseBoundComponent();
+
+  return (promise, render, handleError) => {
+    update(
+      promise,
+      ({ resolved, rejected, result, error }) => ({
+        type: TOAST,
+        render: ({ remove }) =>
+          render({ remove, resolved, rejected, result, error }),
+      }),
+      handleError,
+    );
+  };
 };
 
 export const ToastConnector = ({ children }) => {

--- a/src/lib/component/toast/index.js
+++ b/src/lib/component/toast/index.js
@@ -1,2 +1,8 @@
-export { default as ExecuteCheckStatusToast } from "./ExecuteCheckStatusToast";
-export { default as PublishCheckStatusToast } from "./PublishCheckStatusToast";
+export {
+  default as ExecuteCheckStatusToast,
+  useExecuteCheckStatusToast,
+} from "./ExecuteCheckStatusToast";
+export {
+  default as PublishCheckStatusToast,
+  usePublishCheckStatusToast,
+} from "./PublishCheckStatusToast";

--- a/src/lib/error/index.js
+++ b/src/lib/error/index.js
@@ -1,3 +1,9 @@
-import "./FetchError";
-import "./QueryAbortedError";
-import "./ReactError";
+export {
+  default as FetchError,
+  FailedError,
+  ServerError,
+  ClientError,
+  UnauthorizedError,
+} from "./FetchError";
+export { default as QueryAbortedError } from "./QueryAbortedError";
+export { default as ReactError } from "./ReactError";


### PR DESCRIPTION
## What is this change?

Handle check execute and publish/unpublish errors by displaying error toasts leveraging newly created utilities for implementing status toasts for async actions.

## Why is this change necessary?

Errors network/api errors encountered during graphql mutations should not result in an app crash state but should still alert the user. 

## Does your change need a Changelog entry?

Yes, but as a summary of changes from this and further PRs which add additional error handling.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

There are some large diffs in component files that were migrated from a class implementation to functional components. This was a necessary change to be able to use React hooks (which underpin the new toast-creation utilities) in these locations. There are no other intended changes to look out for.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manual testing of the affected views.
