### PR TITLE
Prevent non Error instances from breaking the error handler

### DIFF
--- a/src/lib/component/root/ErrorRoot.js
+++ b/src/lib/component/root/ErrorRoot.js
@@ -40,18 +40,20 @@ const ErrorRoot = ({ error: rawError }) => {
 
   const error = React.useMemo(() => unwrapError(rawError), [rawError]);
 
-  const frames = React.useMemo(
-    () =>
-      ErrorStackParser.parse(error).map(frame => {
+  const frames = React.useMemo(() => {
+    try {
+      return ErrorStackParser.parse(error).map(frame => {
         const fileName = frame.fileName.replace(window.location.origin, "");
 
         return {
           functionName: `${frame.functionName}`,
           source: `${fileName}:${frame.lineNumber}`,
         };
-      }),
-    [error],
-  );
+      });
+    } catch (e) {
+      return [];
+    }
+  }, [error]);
 
   const issueURL = `https://github.com/sensu/web/issues/new?title=${encodeURIComponent(
     `Unexpected Error: "${error.message}"`,
@@ -140,7 +142,7 @@ ${"```"}`
             <Typography variant="body2">Expand for error details</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
-            <Pre>{error.stack}</Pre>
+            <Pre>{error.stack || error.message}</Pre>
           </ExpansionPanelDetails>
         </ExpansionPanel>
       </ExpansionPanelWrapper>

--- a/src/lib/exceptionHandler/index.js
+++ b/src/lib/exceptionHandler/index.js
@@ -26,7 +26,8 @@ const handle = error => {
   try {
     frames = ErrorStackParser.parse(error);
   } catch (e) {
-    frames = [];
+    renderError(error);
+    return;
   }
 
   // Detect that the caught error originated from our own code. If the source

--- a/src/lib/util/error.js
+++ b/src/lib/util/error.js
@@ -38,5 +38,17 @@ export const unwrapError = error => {
     };
   }
 
-  return { message: `${error}`, stack: "", name: "Error" };
+  let message;
+
+  try {
+    message = `${JSON.stringify(error, null, 2)}`;
+  } catch (e) {
+    message = `${error}`;
+  }
+
+  return {
+    message,
+    stack: "",
+    name: "Error",
+  };
 };


### PR DESCRIPTION
## What is this change?

Patch a flaw in the global error handling logic to ensure that values that are not `Error` class instances are displayed.

## Why is this change necessary?

Closes #104

## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manual in-browser testing.
