### PR TITLE
Allow users to view a collection of Handlers

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -26,6 +26,7 @@ import {
   CheckIcon,
   EntityIcon,
   EventIcon,
+  HandlerIcon,
   SilenceIcon,
 } from "/lib/component/icon";
 
@@ -35,6 +36,7 @@ import {
   ChecksView,
   EntitiesView,
   EventsView,
+  HandlersView,
   SilencesView,
   NotFoundView,
   CheckDetailsView,
@@ -86,6 +88,11 @@ const renderApp = () => {
                       caption: "Checks",
                     },
                     {
+                      to: `${props.match.url}/handlers`,
+                      icon: HandlerIcon,
+                      caption: "Handlers",
+                    },
+                    {
                       to: `${props.match.url}/silences`,
                       icon: SilenceIcon,
                       caption: "Silences",
@@ -121,6 +128,10 @@ const renderApp = () => {
                     <Route
                       path={`${props.match.path}/events`}
                       component={EventsView}
+                    />
+                    <Route
+                      path={`${props.match.path}/handlers`}
+                      component={HandlersView}
                     />
                     <Route
                       path={`${props.match.path}/silences`}

--- a/src/lib/component/icon/index.js
+++ b/src/lib/component/icon/index.js
@@ -21,6 +21,7 @@ export {
 } from "@material-ui/icons/FavoriteBorder";
 export { default as FavoriteIcon } from "@material-ui/icons/Favorite";
 export { default as FeedbackIcon } from "@material-ui/icons/Feedback";
+export { default as HandlerIcon } from "@material-ui/icons/DeviceHub";
 export { default as InfoIcon } from "@material-ui/icons/Info";
 export { default as KebabIcon } from "@material-ui/icons/MoreVert";
 export {

--- a/src/lib/component/partial/HandlersList/HandlersList.js
+++ b/src/lib/component/partial/HandlersList/HandlersList.js
@@ -1,0 +1,139 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+import { withApollo } from "/vendor/react-apollo";
+
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "/vendor/@material-ui/core";
+
+import { ListController } from "/lib/component/controller";
+import { Loader, TableListEmptyState } from "/lib/component/base";
+
+import Pagination from "/lib/component/partial/Pagination";
+
+import HandlersListHeader from "./HandlersListHeader";
+import HandlersListItem from "./HandlersListItem";
+
+const HandlersList = ({
+  editable,
+  loading,
+  filters,
+  limit,
+  namespace,
+  offset,
+  order,
+  onChangeQuery,
+  onChangeFilters,
+}) => {
+  const items = namespace
+    ? namespace.handlers.nodes.filter(hd => !hd.deleted)
+    : [];
+
+  return (
+    <ListController
+      items={items}
+      getItemKey={handler => handler.id}
+      renderEmptyState={() => {
+        return (
+          <TableRow>
+            <TableCell>
+              <TableListEmptyState
+                loading={loading}
+                primary="No results matched your query."
+                secondary="
+              Try refining your search query in the search box. The filter
+              buttons above are also a helpful way of quickly finding entities.
+            "
+              />
+            </TableCell>
+          </TableRow>
+        );
+      }}
+      renderItem={({ key, item: handler }) => (
+        <HandlersListItem key={key} handler={handler} />
+      )}
+    >
+      {({ children, selectedItems }) => (
+        <Paper>
+          <Loader loading={loading}>
+            <HandlersListHeader
+              editable={editable}
+              filters={filters}
+              selectedItems={selectedItems}
+              rowCount={children.length || 0}
+              order={order}
+              onChangeFilters={onChangeFilters}
+              onChangeQuery={onChangeQuery}
+            />
+            <Table>
+              <TableBody>{children}</TableBody>
+            </Table>
+
+            <Pagination
+              limit={limit}
+              offset={offset}
+              pageInfo={namespace && namespace.handlers.pageInfo}
+              onChangeQuery={onChangeQuery}
+            />
+          </Loader>
+        </Paper>
+      )}
+    </ListController>
+  );
+};
+
+HandlersList.propTypes = {
+  editable: PropTypes.bool,
+  namespace: PropTypes.shape({
+    handlers: PropTypes.shape({
+      nodes: PropTypes.array.isRequired,
+    }),
+  }),
+  loading: PropTypes.bool,
+  filters: PropTypes.object,
+  onChangeFilters: PropTypes.func,
+  onChangeQuery: PropTypes.func.isRequired,
+  limit: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  offset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  order: PropTypes.string.isRequired,
+};
+
+HandlersList.defaultProps = {
+  editable: true,
+  namespace: null,
+  loading: false,
+  limit: undefined,
+  offset: undefined,
+  filters: {},
+  onChangeFilters: () => null,
+};
+
+HandlersList.fragments = {
+  namespace: gql`
+    fragment HandlersList_namespace on Namespace {
+      handlers(
+        limit: $limit
+        offset: $offset
+        orderBy: $order
+        filters: $filters
+      ) @connection(key: "handlers", filter: ["filters", "orderBy"]) {
+        nodes {
+          ...HandlersListItem_handler
+        }
+
+        pageInfo {
+          ...Pagination_pageInfo
+        }
+      }
+    }
+    ${HandlersListItem.fragments.handler}
+    ${Pagination.fragments.pageInfo}
+  `,
+};
+
+export default withApollo(HandlersList);

--- a/src/lib/component/partial/HandlersList/HandlersListHeader.js
+++ b/src/lib/component/partial/HandlersList/HandlersListHeader.js
@@ -1,0 +1,80 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+
+import ListHeader from "/lib/component/partial/ListHeader";
+import ListSortSelector from "/lib/component/partial/ListSortSelector";
+import ToolbarMenu from "/lib/component/partial/ToolbarMenu";
+import { SelectMenuItem } from "/lib/component/partial/ToolbarMenuItems";
+import { ToolbarSelectOption } from "/lib/component/partial/ToolbarSelect";
+
+import { toggleParam } from "/lib/util/filterParams";
+
+const HANDLER_TYPES = [
+  { label: "PIPE", value: "pipe" },
+  { label: "SET", value: "set" },
+  { label: "TCP", value: "tcp" },
+  { label: "UDP", value: "udp" },
+];
+
+const HandlersListHeader = ({
+  editable,
+  filters,
+  selectedItems,
+  rowCount,
+  onChangeQuery,
+  onChangeFilters,
+  order,
+}) => {
+  const onFilterHandlerType = toggleParam("type", onChangeFilters);
+  const onSort = onChangeQuery;
+  return (
+    <ListHeader
+      sticky
+      editable={editable}
+      selectedCount={selectedItems.length}
+      rowCount={rowCount}
+      renderActions={() => (
+        <ToolbarMenu>
+          <ToolbarMenu.Item key="type-filter" visible="always">
+            <SelectMenuItem title="Type" onChange={onFilterHandlerType}>
+              <ToolbarSelectOption value={null} />
+              {HANDLER_TYPES.map(({ label, value }) => (
+                <ToolbarSelectOption
+                  key={value}
+                  value={value}
+                  selected={filters.type === value}
+                >
+                  {label}
+                </ToolbarSelectOption>
+              ))}
+            </SelectMenuItem>
+          </ToolbarMenu.Item>
+          <ToolbarMenu.Item key="sort" visible="if-room">
+            <ListSortSelector
+              options={[{ label: "Name", value: "NAME" }]}
+              onChangeQuery={onSort}
+              value={order}
+            />
+          </ToolbarMenu.Item>
+        </ToolbarMenu>
+      )}
+    />
+  );
+};
+
+HandlersListHeader.propTypes = {
+  editable: PropTypes.bool,
+  filters: PropTypes.object,
+  selectedItems: PropTypes.array.isRequired,
+  rowCount: PropTypes.number.isRequired,
+  onChangeQuery: PropTypes.func.isRequired,
+  onChangeFilters: PropTypes.func.isRequired,
+  order: PropTypes.string.isRequired,
+};
+
+HandlersListHeader.defaultProps = {
+  editable: false,
+  filters: {},
+};
+
+export default HandlersListHeader;

--- a/src/lib/component/partial/HandlersList/HandlersListItem.js
+++ b/src/lib/component/partial/HandlersList/HandlersListItem.js
@@ -1,0 +1,50 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+
+import { NamespaceLink } from "/lib/component/util";
+import { TableRow } from "/vendor/@material-ui/core";
+
+import ResourceDetails from "/lib/component/partial/ResourceDetails";
+import TableOverflowCell from "/lib/component/partial/TableOverflowCell";
+
+import HandlersListItemDetails from "./HandlersListItemDetails";
+
+const HandlersListItem = ({ handler }) => (
+  <TableRow>
+    <TableOverflowCell>
+      <ResourceDetails
+        title={
+          <NamespaceLink
+            namespace={handler.namespace}
+            to={`/handers/${handler.name}`}
+          >
+            <strong>{handler.name} </strong>
+          </NamespaceLink>
+        }
+        details={<HandlersListItemDetails handler={handler} />}
+      />
+    </TableOverflowCell>
+  </TableRow>
+);
+
+HandlersListItem.propTypes = {
+  handler: PropTypes.object.isRequired,
+};
+
+HandlersListItem.fragments = {
+  handler: gql`
+    fragment HandlersListItem_handler on Handler {
+      id
+      name
+      namespace
+      command
+
+      ...HandlersListItemDetails_handler
+    }
+
+    ${HandlersListItemDetails.fragments.handler}
+  `,
+};
+
+export default HandlersListItem;

--- a/src/lib/component/partial/HandlersList/HandlersListItem.js
+++ b/src/lib/component/partial/HandlersList/HandlersListItem.js
@@ -17,7 +17,7 @@ const HandlersListItem = ({ handler }) => (
         title={
           <NamespaceLink
             namespace={handler.namespace}
-            to={`/handers/${handler.name}`}
+            to={`/handlers/${handler.name}`}
           >
             <strong>{handler.name} </strong>
           </NamespaceLink>

--- a/src/lib/component/partial/HandlersList/HandlersListItemDetails.js
+++ b/src/lib/component/partial/HandlersList/HandlersListItemDetails.js
@@ -1,0 +1,89 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+
+import { Code, CodeHighlight } from "/lib/component/base";
+import { Maybe, NamespaceLink } from "/lib/component/util";
+
+const HandlersListItemDetails = ({ handler }) => (
+  <React.Fragment>
+    <div>
+      {`Type: `}
+      <strong>{handler.type}</strong>
+    </div>
+
+    <Maybe value={handler.type === "pipe"}>
+      {() => (
+        <React.Fragment>
+          {`Command: `}
+          <CodeHighlight
+            language="bash"
+            code={handler.command}
+            component={Code}
+          />
+        </React.Fragment>
+      )}
+    </Maybe>
+
+    <Maybe value={handler.type === "set"}>
+      {() => (
+        <React.Fragment>
+          {`Handlers: [ `}
+          {handler.handlers.map((hd, idx, arr) => (
+            <React.Fragment key={hd.name}>
+              <NamespaceLink
+                namespace={hd.namespace}
+                to={`/handers/${hd.name}`}
+              >
+                <CodeHighlight
+                  language="json"
+                  code={`${hd.name}`}
+                  component={Code}
+                />
+              </NamespaceLink>
+              {idx < arr.length - 1 ? ", " : ""}
+            </React.Fragment>
+          ))}
+          {` ]`}
+        </React.Fragment>
+      )}
+    </Maybe>
+
+    <Maybe value={handler.type === "tcp" || handler.type === "udp"}>
+      {() => (
+        <React.Fragment>
+          {`Socket: `}
+          <CodeHighlight
+            language="json"
+            code={`${handler.type}://${handler.socket.host}:${
+              handler.socket.port
+            }`}
+            component={Code}
+          />
+        </React.Fragment>
+      )}
+    </Maybe>
+  </React.Fragment>
+);
+
+HandlersListItemDetails.propTypes = {
+  handler: PropTypes.object.isRequired,
+};
+
+HandlersListItemDetails.fragments = {
+  handler: gql`
+    fragment HandlersListItemDetails_handler on Handler {
+      type
+      command
+      handlers {
+        name
+      }
+      socket {
+        port
+        host
+      }
+    }
+  `,
+};
+
+export default HandlersListItemDetails;

--- a/src/lib/component/partial/HandlersList/HandlersListItemDetails.js
+++ b/src/lib/component/partial/HandlersList/HandlersListItemDetails.js
@@ -33,7 +33,7 @@ const HandlersListItemDetails = ({ handler }) => (
             <React.Fragment key={hd.name}>
               <NamespaceLink
                 namespace={hd.namespace}
-                to={`/handers/${hd.name}`}
+                to={`/handlers/${hd.name}`}
               >
                 <CodeHighlight
                   language="json"

--- a/src/lib/component/partial/HandlersList/HandlersListToolbar.js
+++ b/src/lib/component/partial/HandlersList/HandlersListToolbar.js
@@ -1,0 +1,47 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+
+import { ResetMenuItem } from "/lib/component/partial/ToolbarMenuItems";
+
+import ToolbarMenu from "/lib/component/partial/ToolbarMenu";
+import ListToolbar from "/lib/component/partial/ListToolbar";
+
+class HandlersListToolbar extends React.PureComponent {
+  static propTypes = {
+    onClickReset: PropTypes.func.isRequired,
+    toolbarContent: PropTypes.node,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarContent: <React.Fragment />,
+    toolbarItems: ({ items }) => items,
+  };
+
+  render() {
+    const { onClickReset, toolbarItems, toolbarContent } = this.props;
+
+    return (
+      <ListToolbar
+        search={toolbarContent}
+        toolbarItems={props => (
+          <ToolbarMenu>
+            {toolbarItems({
+              ...props,
+              items: [
+                <ToolbarMenu.Item
+                  key="reset"
+                  visible={props.collapsed ? "never" : "if-room"}
+                >
+                  <ResetMenuItem onClick={onClickReset} />
+                </ToolbarMenu.Item>,
+              ],
+            })}
+          </ToolbarMenu>
+        )}
+      />
+    );
+  }
+}
+
+export default HandlersListToolbar;

--- a/src/lib/component/partial/HandlersList/index.js
+++ b/src/lib/component/partial/HandlersList/index.js
@@ -1,0 +1,2 @@
+export { default } from "./HandlersList";
+export { default as HandlersListToolbar } from "./HandlersListToolbar";

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -21,6 +21,7 @@ export { default as EntityStatusDescriptor } from "./EntityStatusDescriptor";
 export { default as EventDetailsContainer } from "./EventDetailsContainer";
 export { default as EventStatusDescriptor } from "./EventStatusDescriptor";
 export { default as EventsList, EventsListToolbar } from "./EventsList";
+export { default as HandlersList, HandlersListToolbar } from "./HandlersList";
 export { default as Label } from "./Label";
 export { default as LabelsAnnotationsCell } from "./LabelsAnnotationsCell";
 export { default as ListHeader } from "./ListHeader";

--- a/src/lib/component/view/HandlersView.js
+++ b/src/lib/component/view/HandlersView.js
@@ -1,0 +1,142 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+
+import { parseFilterParams, buildFilterParams } from "/lib/util/filterParams";
+import { pollingDuration } from "/lib/constant/polling";
+import { FailedError } from "/lib/error/FetchError";
+
+import {
+  Content,
+  FilterList,
+  MobileFullWidthContent,
+} from "/lib/component/base";
+import {
+  AppLayout,
+  HandlersList,
+  HandlersListToolbar,
+  NotFound,
+} from "/lib/component/partial";
+
+import { Query, withQueryParams } from "/lib/component/util";
+
+class HandlersView extends React.Component {
+  static propTypes = {
+    match: PropTypes.object.isRequired,
+    queryParams: PropTypes.shape({
+      offset: PropTypes.string,
+      limit: PropTypes.string,
+    }).isRequired,
+    setQueryParams: PropTypes.func.isRequired,
+    toolbarContent: PropTypes.func,
+    toolbarItems: PropTypes.func,
+  };
+
+  static defaultProps = {
+    toolbarContent: ({ filters, setFilters }) => (
+      <FilterList filters={filters} onChange={setFilters} />
+    ),
+    toolbarItems: undefined,
+  };
+
+  static query = gql`
+    query EnvironmentViewHandlersViewQuery(
+      $namespace: String!
+      $limit: Int
+      $offset: Int
+      $order: HandlerListOrder
+      $filters: [String!]
+    ) {
+      namespace(name: $namespace) {
+        ...HandlersList_namespace
+      }
+    }
+
+    ${HandlersList.fragments.namespace}
+  `;
+
+  render() {
+    const {
+      match,
+      queryParams,
+      setQueryParams,
+      toolbarItems,
+      toolbarContent,
+    } = this.props;
+    const { limit, offset } = queryParams;
+    const variables = { ...match.params, ...queryParams };
+
+    const filters = parseFilterParams(queryParams.filters);
+    const setFilters = setter => {
+      const next = setter(filters);
+      setQueryParams({ filters: buildFilterParams(next) });
+    };
+
+    return (
+      <AppLayout namespace={match.params.namespace}>
+        <Query
+          query={HandlersView.query}
+          fetchPolicy="cache-and-network"
+          pollInterval={pollingDuration.short}
+          variables={variables}
+          onError={error => {
+            if (error.networkError instanceof FailedError) {
+              return;
+            }
+
+            throw error;
+          }}
+        >
+          {({ aborted, data: { namespace } = {}, networkStatus, refetch }) => {
+            // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
+            const loading = networkStatus < 6;
+
+            if (!namespace && !loading && !aborted) {
+              return <NotFound />;
+            }
+
+            return (
+              <div>
+                <Content marginBottom>
+                  <HandlersListToolbar
+                    onClickReset={() => setQueryParams(q => q.reset())}
+                    toolbarContent={toolbarContent({
+                      filters,
+                      setFilters,
+                    })}
+                    toolbarItems={toolbarItems}
+                  />
+                </Content>
+
+                <MobileFullWidthContent>
+                  <HandlersList
+                    editable={false}
+                    limit={limit}
+                    filters={filters}
+                    offset={offset}
+                    onChangeQuery={setQueryParams}
+                    onChangeFilters={setFilters}
+                    namespace={namespace}
+                    loading={(loading && !namespace) || aborted}
+                    refetch={refetch}
+                    order={queryParams.order}
+                  />
+                </MobileFullWidthContent>
+              </div>
+            );
+          }}
+        </Query>
+      </AppLayout>
+    );
+  }
+}
+
+const enhance = withQueryParams({
+  keys: ["filters", "order", "offset", "limit"],
+  defaults: {
+    limit: "25",
+    offset: "0",
+    order: "NAME",
+  },
+});
+export default enhance(HandlersView);

--- a/src/lib/component/view/index.js
+++ b/src/lib/component/view/index.js
@@ -4,6 +4,7 @@ export { default as EntitiesView } from "./EntitiesView";
 export { default as EntityDetailsView } from "./EntityDetailsView";
 export { default as EventDetailsView } from "./EventDetailsView";
 export { default as EventsView } from "./EventsView";
+export { default as HandlersView } from "./HandlersView";
 export { default as NamespaceNotFoundView } from "./NamespaceNotFoundView";
 export { default as NotFoundView } from "./NotFoundView";
 export { default as SignInView } from "./SignInView";


### PR DESCRIPTION
## What is this change?
⚠️ This change requires https://github.com/sensu/sensu-go/pull/2951

This change allows users to navigate to `/:namespace/handlers` route to view a collection of Handlers fetched from GraphQL. This PR address part of sensu/web#89, the rest of this issue will be address in a separate PR. 

From the Handlers collection view users can:
1. Sort Handlers by `name` using a select dropdown.
2. Filter Handlers by `type` (`pipe`, `set`, `tcp`, or `udp`) using a select dropdown.

Handlers shown in the collection are displayed with contextual details determined by the 'type' of handler in the list (`pipe`, `set`, `tcp`,`udp`). Each type displays details that are relevant to the handler type. For example, `pipe` handlers display the command property and `tcp` handlers display socket information (port, host). 

**Handler List Demo:**
![BF1MIjy73l](https://user-images.githubusercontent.com/3856248/57878696-723c4980-77cf-11e9-93ff-7e7f3c9f2944.gif)

## Why is this change necessary?
This change addresses sensu/web#89 _(Web UI - Implement Handler list and detail views)_
> As a Sensu user, I would like the ability to view a list of my handlers and see the details of a particular one that I select.

## Do you need clarification on anything?
Nope.

## Were there any complications while making this change?
Nope.

## Have you reviewed and updated the documentation for this change? Is new documentation required?
Nope.

## How did you verify this change?
Manually. Build and run the branch locally, create some handlers, then navigate to `/:namespace/handers` to view the list of handlers. 

