### PR TITLE
Allow users to view the configuration of an individual Handler

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -42,6 +42,7 @@ import {
   CheckDetailsView,
   EventDetailsView,
   EntityDetailsView,
+  HandlerDetailsView,
   NamespaceNotFoundView,
 } from "/lib/component/view";
 
@@ -116,6 +117,10 @@ const renderApp = () => {
                     <Route
                       path={`${props.match.path}/entities/:entity`}
                       component={EntityDetailsView}
+                    />
+                    <Route
+                      path={`${props.match.path}/handlers/:handler`}
+                      component={HandlerDetailsView}
                     />
                     <Route
                       path={`${props.match.path}/checks`}

--- a/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsConfiguration.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsConfiguration.js
@@ -1,0 +1,213 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+
+import {
+  Card,
+  CardContent,
+  Divider,
+  Grid,
+  Typography,
+} from "/vendor/@material-ui/core";
+
+import { Maybe, NamespaceLink } from "/lib/component/util";
+
+import {
+  Code,
+  CodeBlock,
+  CodeHighlight,
+  Duration,
+  Dictionary,
+  DictionaryKey,
+  DictionaryValue,
+  DictionaryEntry,
+} from "/lib/component/base";
+
+import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
+
+const HandlerDetailsConfiguration = ({ handler }) => (
+  <Card>
+    <CardContent>
+      <Typography variant="h5" gutterBottom>
+        Handler Configuration
+      </Typography>
+      <Grid container spacing={0}>
+        <Grid item xs={12} sm={6}>
+          <Dictionary>
+            <DictionaryEntry>
+              <DictionaryKey>Name</DictionaryKey>
+              <DictionaryValue>{handler.name}</DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Type</DictionaryKey>
+              <DictionaryValue>{handler.type}</DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Filters</DictionaryKey>
+              <DictionaryValue>
+                <Maybe value={handler.filters.length > 0} fallback="—">
+                  {() => (
+                    <React.Fragment>
+                      {handler.filters.map(filter => (
+                        <div key={filter}>
+                          <CodeHighlight
+                            key={filter}
+                            language="json"
+                            code={`${filter}`}
+                            component={Code}
+                          />
+                        </div>
+                      ))}
+                    </React.Fragment>
+                  )}
+                </Maybe>
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <Dictionary>
+            <DictionaryEntry>
+              <DictionaryKey>Socket</DictionaryKey>
+              <DictionaryValue>
+                <Maybe
+                  value={handler.type === "tcp" || handler.type === "udp"}
+                  fallback="—"
+                >
+                  {() => (
+                    <CodeHighlight
+                      language="json"
+                      code={`${handler.type}://${handler.socket.host}:${
+                        handler.socket.port
+                      }`}
+                      component={Code}
+                    />
+                  )}
+                </Maybe>
+              </DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Timeout</DictionaryKey>
+              <DictionaryValue>
+                <Maybe value={handler.timeout > 0} fallback="—">
+                  {val => (val ? <Duration duration={val * 1000} /> : "Never")}
+                </Maybe>
+              </DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Handlers</DictionaryKey>
+              <DictionaryValue>
+                <Maybe value={handler.type === "set"} fallback="—">
+                  {() => (
+                    <React.Fragment>
+                      {handler.handlers.map(hd => (
+                        <div key={hd.name}>
+                          <NamespaceLink
+                            namespace={hd.namespace}
+                            to={`/handlers/${hd.name}`}
+                          >
+                            <CodeHighlight
+                              language="json"
+                              code={`${hd.name}`}
+                              component={Code}
+                            />
+                          </NamespaceLink>
+                        </div>
+                      ))}
+                    </React.Fragment>
+                  )}
+                </Maybe>
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+    <Divider />
+    <CardContent>
+      <Grid container spacing={0}>
+        <Grid item xs={12}>
+          <Dictionary>
+            <DictionaryEntry fullWidth={!!handler.command}>
+              <DictionaryKey>Command</DictionaryKey>
+              <DictionaryValue>
+                {handler.command ? (
+                  <CodeBlock>
+                    <CodeHighlight
+                      language="bash"
+                      code={handler.command}
+                      component={Code}
+                    />
+                  </CodeBlock>
+                ) : (
+                  "None"
+                )}
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+    <Divider />
+    <CardContent>
+      <Grid container spacing={0}>
+        <Grid item xs={12}>
+          <Dictionary>
+            <DictionaryEntry fullWidth={handler.envVars.length > 0}>
+              <DictionaryKey>ENV Vars</DictionaryKey>
+              <DictionaryValue>
+                {handler.envVars.length > 0 ? (
+                  <CodeBlock>
+                    <CodeHighlight
+                      language="properties"
+                      code={handler.envVars.join("\n")}
+                      component={Code}
+                    />
+                  </CodeBlock>
+                ) : (
+                  "None"
+                )}
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+    <Divider />
+    <LabelsAnnotationsCell handler={handler} />
+  </Card>
+);
+
+HandlerDetailsConfiguration.propTypes = {
+  handler: PropTypes.object,
+};
+
+HandlerDetailsConfiguration.defaultProps = {
+  handler: null,
+};
+
+HandlerDetailsConfiguration.fragments = {
+  handler: gql`
+    fragment HandlerDetailsConfiguration_handler on Handler {
+      name
+      type
+      command
+      timeout
+      handlers {
+        name
+      }
+      socket {
+        port
+        host
+      }
+      filters
+      envVars
+      metadata {
+        ...LabelsAnnotationsCell_objectmeta
+      }
+    }
+    ${LabelsAnnotationsCell.fragments.objectmeta}
+  `,
+};
+
+export default HandlerDetailsConfiguration;

--- a/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsContainer.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsContainer.js
@@ -1,0 +1,49 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+
+import { Grid } from "/vendor/@material-ui/core";
+
+import { Content, Loader } from "/lib/component/base";
+
+import Configuration from "./HandlerDetailsConfiguration";
+import Toolbar from "./HandlerDetailsToolbar";
+
+const HandlerDetailsContainer = ({ handler, loading, toolbarItems }) => (
+  <Loader loading={loading} passthrough>
+    {handler && (
+      <React.Fragment>
+        <Content marginBottom>
+          <Toolbar toolbarItems={toolbarItems} />
+        </Content>
+        <Grid container spacing={16}>
+          <Grid item xs={12}>
+            <Configuration handler={handler} />
+          </Grid>
+        </Grid>
+      </React.Fragment>
+    )}
+  </Loader>
+);
+
+HandlerDetailsContainer.propTypes = {
+  handler: PropTypes.object,
+  loading: PropTypes.bool.isRequired,
+  toolbarItems: PropTypes.func,
+};
+
+HandlerDetailsContainer.defaultProps = {
+  handler: null,
+  toolbarItems: undefined,
+};
+
+HandlerDetailsContainer.fragments = {
+  handler: gql`
+    fragment HandlerDetailsContainer_handler on Handler {
+      ...HandlerDetailsConfiguration_handler
+    }
+    ${Configuration.fragments.handler}
+  `,
+};
+
+export default HandlerDetailsContainer;

--- a/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsToolbar.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsToolbar.js
@@ -1,0 +1,19 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+
+import Toolbar from "/lib/component/partial/Toolbar";
+import ToolbarMenu from "/lib/component/partial/ToolbarMenu";
+
+const HandlerDetailsToolbar = ({ toolbarItems }) => (
+  <Toolbar right={<ToolbarMenu>{toolbarItems({ items: [] })}</ToolbarMenu>} />
+);
+
+HandlerDetailsToolbar.propTypes = {
+  toolbarItems: PropTypes.func,
+};
+
+HandlerDetailsToolbar.defaultProps = {
+  toolbarItems: ({ items }) => items,
+};
+
+export default HandlerDetailsToolbar;

--- a/src/lib/component/partial/HandlerDetailsContainer/index.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/index.js
@@ -1,0 +1,1 @@
+export { default } from "./HandlerDetailsContainer";

--- a/src/lib/component/partial/LabelsAnnotationsCell/LabelsAnnotationsCell.js
+++ b/src/lib/component/partial/LabelsAnnotationsCell/LabelsAnnotationsCell.js
@@ -30,11 +30,13 @@ class LabelsAnnotationsCell extends React.PureComponent {
     classes: PropTypes.object.isRequired,
     entity: PropTypes.object,
     check: PropTypes.object,
+    handler: PropTypes.object,
   };
 
   static defaultProps = {
     entity: null,
     check: null,
+    handler: null,
   };
 
   static fragments = {
@@ -53,9 +55,9 @@ class LabelsAnnotationsCell extends React.PureComponent {
   };
 
   render() {
-    const { check, classes, entity } = this.props;
+    const { check, classes, entity, handler } = this.props;
 
-    const object = check || entity;
+    const object = check || entity || handler;
 
     const annotations = Object.keys(object.metadata.annotations).reduce(
       (anno, key) => {

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -22,6 +22,7 @@ export { default as EventDetailsContainer } from "./EventDetailsContainer";
 export { default as EventStatusDescriptor } from "./EventStatusDescriptor";
 export { default as EventsList, EventsListToolbar } from "./EventsList";
 export { default as HandlersList, HandlersListToolbar } from "./HandlersList";
+export { default as HandlerDetailsContainer } from "./HandlerDetailsContainer";
 export { default as Label } from "./Label";
 export { default as LabelsAnnotationsCell } from "./LabelsAnnotationsCell";
 export { default as ListHeader } from "./ListHeader";

--- a/src/lib/component/view/HandlerDetailsView.js
+++ b/src/lib/component/view/HandlerDetailsView.js
@@ -1,0 +1,72 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import gql from "/vendor/graphql-tag";
+
+import { pollingDuration } from "/lib/constant/polling";
+
+import { FailedError } from "/lib/error/FetchError";
+
+import { Query } from "/lib/component/util";
+
+import {
+  AppLayout,
+  NotFound,
+  HandlerDetailsContainer,
+} from "/lib/component/partial";
+
+const query = gql`
+  query HandlerDetailsContentQuery($namespace: String!, $handler: String!) {
+    handler(namespace: $namespace, name: $handler) {
+      ...HandlerDetailsContainer_handler
+    }
+  }
+
+  ${HandlerDetailsContainer.fragments.handler}
+`;
+
+const HandlerDetailsView = ({ match, toolbarItems }) => (
+  <AppLayout namespace={match.params.namespace}>
+    <Query
+      query={query}
+      pollInterval={pollingDuration.short}
+      fetchPolicy="cache-and-network"
+      variables={match.params}
+      onError={error => {
+        if (error.networkError instanceof FailedError) {
+          return;
+        }
+
+        throw error;
+      }}
+    >
+      {({ aborted, client, data: { handler } = {}, networkStatus }) => {
+        // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
+        const loading = networkStatus < 6;
+
+        if (!loading && !aborted && !handler) {
+          return <NotFound />;
+        }
+
+        return (
+          <HandlerDetailsContainer
+            toolbarItems={toolbarItems}
+            client={client}
+            handler={handler}
+            loading={loading || aborted}
+          />
+        );
+      }}
+    </Query>
+  </AppLayout>
+);
+
+HandlerDetailsView.propTypes = {
+  match: PropTypes.object.isRequired,
+  toolbarItems: PropTypes.func,
+};
+
+HandlerDetailsView.defaultProps = {
+  toolbarItems: undefined,
+};
+
+export default HandlerDetailsView;

--- a/src/lib/component/view/index.js
+++ b/src/lib/component/view/index.js
@@ -3,6 +3,7 @@ export { default as ChecksView } from "./ChecksView";
 export { default as EntitiesView } from "./EntitiesView";
 export { default as EntityDetailsView } from "./EntityDetailsView";
 export { default as EventDetailsView } from "./EventDetailsView";
+export { default as HandlerDetailsView } from "./HandlerDetailsView";
 export { default as EventsView } from "./EventsView";
 export { default as HandlersView } from "./HandlersView";
 export { default as NamespaceNotFoundView } from "./NamespaceNotFoundView";


### PR DESCRIPTION
## What is this change?

This change allows users to navigate to /:namespace/handlers/:handler_name` route to view the configuration of an individual Handler fetched from GraphQL. This PR address part of #89, the rest of this issue is addressed in #108.

From the Handler details view users can see the following attributes:
 - Name
 - Type
 - Filters (as a list)
 - Socket (the following format: `{scheme}://{host}:{port}`)
 - Timeout
 - Handers (as a click-able list)
 - Command
 - ENV vars
 - Labels
 - Annotations

**Example Handler (pipe handler):**
![Screen Shot 2019-05-16 at 5 35 58 PM](https://user-images.githubusercontent.com/3856248/57895585-315d2880-7801-11e9-94f8-c9b6ed7d5ee9.png)

## Why is this change necessary?
This change addresses #89 
> As a Sensu user, I would like the ability to view a list of my handlers and see the details of a particular one that I select.

## Do you need clarification on anything?
Nope.


## Were there any complications while making this change?
Nope,

## Have you reviewed and updated the documentation for this change? Is new documentation required?
Nope. 

## How did you verify this change?
Manually. Build and run the branch locally, create some handlers, then navigate to `/:namespace/handers/:handler_name` to view an individual handler, given its `namespace` and `name`.

