### PR TITLE
Include `id` field when querying handlers

### DIFF
--- a/src/lib/component/view/HandlerDetailsView.js
+++ b/src/lib/component/view/HandlerDetailsView.js
@@ -17,6 +17,7 @@ import {
 const query = gql`
   query HandlerDetailsContentQuery($namespace: String!, $handler: String!) {
     handler(namespace: $namespace, name: $handler) {
+      id
       ...HandlerDetailsContainer_handler
     }
   }


### PR DESCRIPTION
## What is this change?

Avoids the following error by ensuring the ID is present for the cache to reference.

> "Invariant Violation: Store error" the application attempted to write an object
> with no provided id but the store already contains an id of
> srn:handlers:sensu-devel:... this object. The selectionSet that was
> trying to be written ...
>
> apollographql/apollo-feature-requests#23


## Why is this change necessary?

This changes supports sensu/sensu-enterprise-go/444 ([link](https://github.com/sensu/sensu-enterprise-go/issues/444))

As a user, I can delete a handler through the web UI.

## Does your change need a Changelog entry?
Nope. 

## How did you verify this change?
Manually. 

