### PR TITLE
Add client side `delete` field to Handler type

### DIFF
--- a/src/lib/apollo/resolvers/deleted.graphql
+++ b/src/lib/apollo/resolvers/deleted.graphql
@@ -13,6 +13,11 @@ extend type Event {
   deleted: Boolean!
 }
 
+extend type Handler {
+  "Describes whether the handler has been deleted from the system"
+  deleted: Boolean!
+}
+
 extend type Silenced {
   "Describes whether the entry has been deleted from the system"
   deleted: Boolean!

--- a/src/lib/apollo/stateLink.js
+++ b/src/lib/apollo/stateLink.js
@@ -17,6 +17,7 @@ const stateLink = ({ cache, resolvers }) =>
       addDeletedFieldTo("CheckConfig"),
       addDeletedFieldTo("Entity"),
       addDeletedFieldTo("Event"),
+      addDeletedFieldTo("Handler"),
       addDeletedFieldTo("Silenced"),
       ...resolvers,
     ]),

--- a/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsConfiguration.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsConfiguration.js
@@ -189,6 +189,8 @@ HandlerDetailsConfiguration.defaultProps = {
 HandlerDetailsConfiguration.fragments = {
   handler: gql`
     fragment HandlerDetailsConfiguration_handler on Handler {
+      deleted @client
+      id
       name
       type
       command

--- a/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsContainer.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsContainer.js
@@ -40,6 +40,9 @@ HandlerDetailsContainer.defaultProps = {
 HandlerDetailsContainer.fragments = {
   handler: gql`
     fragment HandlerDetailsContainer_handler on Handler {
+      id
+      deleted @client
+
       ...HandlerDetailsConfiguration_handler
     }
     ${Configuration.fragments.handler}

--- a/src/lib/component/partial/HandlersList/HandlersList.js
+++ b/src/lib/component/partial/HandlersList/HandlersList.js
@@ -123,6 +123,8 @@ HandlersList.fragments = {
         filters: $filters
       ) @connection(key: "handlers", filter: ["filters", "orderBy"]) {
         nodes {
+          id
+          deleted @client
           ...HandlersListItem_handler
         }
 

--- a/src/lib/component/view/HandlerDetailsView.js
+++ b/src/lib/component/view/HandlerDetailsView.js
@@ -18,6 +18,7 @@ const query = gql`
   query HandlerDetailsContentQuery($namespace: String!, $handler: String!) {
     handler(namespace: $namespace, name: $handler) {
       id
+      deleted @client
       ...HandlerDetailsContainer_handler
     }
   }
@@ -44,7 +45,7 @@ const HandlerDetailsView = ({ match, toolbarItems }) => (
         // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
         const loading = networkStatus < 6;
 
-        if (!loading && !aborted && !handler) {
+        if (!loading && !aborted && (!handler || handler.deleted)) {
           return <NotFound />;
         }
 


### PR DESCRIPTION

## What is this change?

In order to track whether a record in the Apollo cache has been deleted, we set a client side field on the resource called `deleted`. This change updates the Handler related components and queries to include the `deleted` attribute.

## Why is this change necessary?

This changes supports sensu/sensu-enterprise-go/444 (link)

> As a user, I can delete a handler through the web UI.

## Does your change need a Changelog entry?
Nope.

## How did you verify this change?
Manually