### PR TITLE
Support non-standard and invalid cron expressions

### DIFF
--- a/src/lib/component/partial/CronDescriptor/CronDescriptor.js
+++ b/src/lib/component/partial/CronDescriptor/CronDescriptor.js
@@ -1,35 +1,41 @@
 import React from "/vendor/react";
 import PropTypes from "prop-types";
 import lowerFirst from "lodash/lowerFirst";
-import cronstrue from "/vendor/cronstrue";
 import { Tooltip } from "/vendor/@material-ui/core";
 
-class CronDescriptor extends React.PureComponent {
-  static propTypes = {
-    capitalize: PropTypes.bool,
-    expression: PropTypes.string.isRequired,
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  };
+import { format } from "/lib/util/cron";
 
-  static defaultProps = {
-    capitalize: false,
-    component: "span",
-  };
-
-  render() {
-    const { capitalize, expression, component: Component } = this.props;
-
-    let statement = cronstrue.toString(expression);
-    if (!capitalize) {
-      statement = lowerFirst(statement);
+const CronDescriptor = ({ capitalize, expression, component: Component }) => {
+  let statement = React.useMemo(() => {
+    try {
+      return format(expression);
+    } catch (e) {
+      // The cron expression could not be formatted, return the raw expression
+      // as a fallback.
+      return expression;
     }
+  }, [expression]);
 
-    return (
-      <Tooltip title={expression}>
-        <Component>{statement}</Component>
-      </Tooltip>
-    );
+  if (!capitalize) {
+    statement = lowerFirst(statement);
   }
-}
+
+  return (
+    <Tooltip title={expression}>
+      <Component>{statement}</Component>
+    </Tooltip>
+  );
+};
+
+CronDescriptor.propTypes = {
+  capitalize: PropTypes.bool,
+  expression: PropTypes.string.isRequired,
+  component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+};
+
+CronDescriptor.defaultProps = {
+  capitalize: false,
+  component: "span",
+};
 
 export default CronDescriptor;

--- a/src/lib/util/cron.js
+++ b/src/lib/util/cron.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-nested-ternary */
+import cronstrue from "cronstrue";
+import { parseDuration, second, minute, hour, day } from "./date";
+
+export const normalize = expression => {
+  if (/^@(yearly|annually)$/.test(expression)) {
+    return "0 0 0 1 1 *";
+  }
+
+  if (/^@monthly$/.test(expression)) {
+    return "0 0 0 1 * *";
+  }
+
+  if (/^@weekly$/.test(expression)) {
+    return "0 0 0 * * 0";
+  }
+
+  if (/^@(daily|midnight)$/.test(expression)) {
+    return "0 0 0 * * *";
+  }
+
+  if (/^@hourly$/.test(expression)) {
+    return "0 0 * * * *";
+  }
+
+  const match = /^@every +(.*)$/.exec(expression);
+  if (match) {
+    const duration = parseDuration(match[1]);
+
+    if (duration % day === 0) {
+      return `0 0 0 */${duration / day} * *`;
+    }
+
+    if (duration % hour === 0) {
+      return `0 0 */${duration / hour} * * *`;
+    }
+
+    if (duration % minute === 0) {
+      return `0 */${duration / minute} * * * *`;
+    }
+
+    const seconds = Math.round(duration / second);
+
+    if (seconds) {
+      return `*/${seconds} * * * * *`;
+    }
+
+    return `* * * * * *`;
+  }
+
+  return expression;
+};
+
+export const format = (expression, options) =>
+  cronstrue.toString(normalize(expression), options);

--- a/src/lib/util/cron.js
+++ b/src/lib/util/cron.js
@@ -25,23 +25,26 @@ export const normalize = expression => {
 
   const match = /^@every +(.*)$/.exec(expression);
   if (match) {
-    const duration = parseDuration(match[1]);
+    // Parse the duration in ms rounded to the nearest second
+    const duration = Math.round(parseDuration(match[1]) / second) * second;
 
-    if (duration % day === 0) {
-      return `0 0 0 */${duration / day} * *`;
+    if (duration > 0) {
+      if (duration % day === 0) {
+        return `0 0 0 */${duration / day} * *`;
+      }
+
+      if (duration % hour === 0) {
+        return `0 0 */${duration / hour} * * *`;
+      }
+
+      if (duration % minute === 0) {
+        return `0 */${duration / minute} * * * *`;
+      }
     }
 
-    if (duration % hour === 0) {
-      return `0 0 */${duration / hour} * * *`;
-    }
+    const seconds = duration / second;
 
-    if (duration % minute === 0) {
-      return `0 */${duration / minute} * * * *`;
-    }
-
-    const seconds = Math.round(duration / second);
-
-    if (seconds) {
+    if (seconds > 0) {
       return `*/${seconds} * * * * *`;
     }
 

--- a/src/lib/util/cron.test.js
+++ b/src/lib/util/cron.test.js
@@ -15,6 +15,9 @@ describe("cron utils", () => {
       expect(normalize("@every 5m")).toEqual("0 */5 * * * *");
       expect(normalize("@every 1h5m")).toEqual("0 */65 * * * *");
       expect(normalize("@every 5s")).toEqual("*/5 * * * * *");
+      expect(normalize("@every 900ms")).toEqual("*/1 * * * * *");
+      expect(normalize("@every 5ms")).toEqual("* * * * * *");
+      expect(normalize("@every 5000000000ns")).toEqual("*/5 * * * * *");
 
       expect(normalize("not a valid expression")).toEqual(
         "not a valid expression",
@@ -37,6 +40,8 @@ describe("cron utils", () => {
       expect(format("@midnight")).toEqual("At 12:00 AM");
       expect(format("@hourly")).toEqual("Every hour");
 
+      expect(format("@every 5000000000ns")).toEqual("Every 5 seconds");
+      expect(format("@every 5ms")).toEqual("Every second");
       expect(format("@every 5s")).toEqual("Every 5 seconds");
       expect(format("@every 5m")).toEqual("Every 5 minutes");
       expect(format("@every 1h5m")).toEqual("Every 65 minutes");

--- a/src/lib/util/cron.test.js
+++ b/src/lib/util/cron.test.js
@@ -18,6 +18,9 @@ describe("cron utils", () => {
       expect(normalize("@every 900ms")).toEqual("*/1 * * * * *");
       expect(normalize("@every 5ms")).toEqual("* * * * * *");
       expect(normalize("@every 5000000000ns")).toEqual("*/5 * * * * *");
+      // 59.9 seconds should be parsed to equal 1 minute
+      expect(normalize("@every 59900ms")).toEqual("0 */1 * * * *");
+      expect(normalize("@every 59.9s")).toEqual("0 */1 * * * *");
 
       expect(normalize("not a valid expression")).toEqual(
         "not a valid expression",
@@ -40,6 +43,8 @@ describe("cron utils", () => {
       expect(format("@midnight")).toEqual("At 12:00 AM");
       expect(format("@hourly")).toEqual("Every hour");
 
+      expect(format("@every 59.9s")).toEqual("Every minute");
+      expect(format("@every 59900ms")).toEqual("Every minute");
       expect(format("@every 5000000000ns")).toEqual("Every 5 seconds");
       expect(format("@every 5ms")).toEqual("Every second");
       expect(format("@every 5s")).toEqual("Every 5 seconds");

--- a/src/lib/util/cron.test.js
+++ b/src/lib/util/cron.test.js
@@ -1,0 +1,50 @@
+import { normalize, format } from "./cron";
+
+describe("cron utils", () => {
+  describe("normalize", () => {
+    it("should convert non-standard expressions to standard format", () => {
+      expect(normalize("@yearly")).toEqual("0 0 0 1 1 *");
+      expect(normalize("@annually")).toEqual("0 0 0 1 1 *");
+      expect(normalize("@monthly")).toEqual("0 0 0 1 * *");
+      expect(normalize("@daily")).toEqual("0 0 0 * * *");
+      expect(normalize("@midnight")).toEqual("0 0 0 * * *");
+      expect(normalize("@hourly")).toEqual("0 0 * * * *");
+
+      expect(normalize("@every 48h")).toEqual("0 0 0 */2 * *");
+      expect(normalize("@every 5h")).toEqual("0 0 */5 * * *");
+      expect(normalize("@every 5m")).toEqual("0 */5 * * * *");
+      expect(normalize("@every 1h5m")).toEqual("0 */65 * * * *");
+      expect(normalize("@every 5s")).toEqual("*/5 * * * * *");
+
+      expect(normalize("not a valid expression")).toEqual(
+        "not a valid expression",
+      );
+
+      expect(() => normalize("@every not a valid duration")).toThrow();
+    });
+  });
+
+  describe("format", () => {
+    it("should correctly format non-standard expressions", () => {
+      expect(format("@yearly")).toEqual(
+        "At 12:00 AM, on day 1 of the month, only in January",
+      );
+      expect(format("@annually")).toEqual(
+        "At 12:00 AM, on day 1 of the month, only in January",
+      );
+      expect(format("@monthly")).toEqual("At 12:00 AM, on day 1 of the month");
+      expect(format("@daily")).toEqual("At 12:00 AM");
+      expect(format("@midnight")).toEqual("At 12:00 AM");
+      expect(format("@hourly")).toEqual("Every hour");
+
+      expect(format("@every 5s")).toEqual("Every 5 seconds");
+      expect(format("@every 5m")).toEqual("Every 5 minutes");
+      expect(format("@every 1h5m")).toEqual("Every 65 minutes");
+      expect(format("@every 4h")).toEqual("Every 4 hours");
+      expect(format("@every 24h")).toEqual("At 12:00 AM");
+      expect(format("@every 48h")).toEqual("At 12:00 AM, every 2 days");
+
+      expect(() => format("not a valid expression")).toThrow();
+    });
+  });
+});

--- a/src/lib/util/date.js
+++ b/src/lib/util/date.js
@@ -44,9 +44,9 @@ export const getDayperiod = date => {
   return "";
 };
 
-export const nanosecond = 1;
-export const microsecond = 1000 * nanosecond;
-export const millisecond = 1000 * microsecond;
+export const millisecond = 1;
+export const microsecond = millisecond / 1000;
+export const nanosecond = microsecond / 1000;
 export const second = 1000 * millisecond;
 export const minute = 60 * second;
 export const hour = 60 * minute;

--- a/src/lib/util/date.js
+++ b/src/lib/util/date.js
@@ -50,6 +50,7 @@ export const nanosecond = microsecond / 1000;
 export const second = 1000 * millisecond;
 export const minute = 60 * second;
 export const hour = 60 * minute;
+export const day = 24 * hour;
 
 export const unitMap = {
   ns: nanosecond,

--- a/src/lib/util/date.js
+++ b/src/lib/util/date.js
@@ -43,3 +43,159 @@ export const getDayperiod = date => {
 
   return "";
 };
+
+export const nanosecond = 1;
+export const microsecond = 1000 * nanosecond;
+export const millisecond = 1000 * microsecond;
+export const second = 1000 * millisecond;
+export const minute = 60 * second;
+export const hour = 60 * minute;
+
+export const unitMap = {
+  ns: nanosecond,
+  us: microsecond,
+  µs: microsecond, // U+00B5 = micro symbol
+  μs: microsecond, // U+03BC = Greek letter mu
+  ms: millisecond,
+  s: second,
+  m: minute,
+  h: hour,
+};
+
+export const parseDuration = original => {
+  let string = original;
+  let duration = 0;
+  let negative = false;
+
+  // Consume [-+]?
+  if (string !== "") {
+    const match = /^[-+]/.exec(string);
+    if (match) {
+      if (match[0] === "-") {
+        negative = true;
+      }
+      string = string.slice(match[0].length);
+    }
+  }
+
+  // Special case: if all that is left is "0", this is zero.
+  if (string === "0") {
+    return 0;
+  }
+
+  if (string === "") {
+    throw new TypeError(`invalid duration ${original}`);
+  }
+
+  let consumedLength = 0;
+
+  const consumeInt = () => {
+    const match = /^[0-9]+/.exec(string);
+    if (match) {
+      consumedLength = match[0].length;
+      string = string.slice(consumedLength);
+      const parsed = parseInt(match[0], 10);
+      if (parsed > Number.MAX_SAFE_INTEGER) {
+        throw new Error("time: bad [0-9]*");
+      }
+      return parseInt(match[0], 10);
+    }
+
+    consumedLength = 0;
+    return 0;
+  };
+
+  const consumeFraction = () => {
+    const match = /^[0-9]+/.exec(string);
+    if (match) {
+      consumedLength = match[0].length;
+      string = string.slice(consumedLength);
+      const scale = 10 ** consumedLength;
+      return [parseInt(match[0], 10), scale];
+    }
+
+    consumedLength = 0;
+    return [0, 1];
+  };
+
+  const consumeDecimal = () => {
+    const match = /^\./.exec(string);
+    if (match) {
+      consumedLength = match[0].length;
+      string = string.slice(consumedLength);
+      return true;
+    }
+
+    consumedLength = 0;
+    return false;
+  };
+
+  const consumeUnit = () => {
+    const match = /^[^0-9.]*/.exec(string);
+    if (match) {
+      consumedLength = match[0].length;
+      string = string.slice(consumedLength);
+
+      return match[0];
+    }
+
+    consumedLength = 0;
+    return "";
+  };
+
+  while (string !== "") {
+    // The next character must be [0-9.]
+    if (!/^[0-9.]/.test(string)) {
+      throw new TypeError(`time: invalid duration ${original}`);
+    }
+
+    const digit = consumeInt();
+    const hasDigit = consumedLength > 0;
+
+    const hasDecimal = consumeDecimal();
+
+    const [[fraction, scale], hasFraction] = hasDecimal
+      ? [consumeFraction(), consumedLength > 0]
+      : [[0, 1], false];
+
+    if (!hasDigit && !hasFraction) {
+      throw new TypeError(`time: invalid duration ${original}`);
+    }
+
+    const unitName = consumeUnit();
+
+    if (!unitName) {
+      throw new TypeError(`time: missing unit in duration ${original}`);
+    }
+
+    const unit = unitMap[unitName];
+
+    if (!unit) {
+      throw new TypeError(
+        `time: unknown unit ${unitName} in duration ${original}`,
+      );
+    }
+
+    let value = digit * unit;
+
+    if (value > Number.MAX_SAFE_INTEGER) {
+      throw new TypeError(`time: invalid duration ${original}`);
+    }
+
+    if (fraction > 0) {
+      value += fraction * (unit / scale);
+    }
+
+    if (value > Number.MAX_SAFE_INTEGER) {
+      throw new TypeError(`time: invalid duration ${original}`);
+    }
+
+    duration += value;
+
+    if (duration > Number.MAX_SAFE_INTEGER) {
+      throw new TypeError(`time: invalid duration ${original}`);
+    }
+  }
+
+  return negative ? -duration : duration;
+};

--- a/src/lib/util/date.js
+++ b/src/lib/util/date.js
@@ -94,10 +94,6 @@ export const parseDuration = original => {
     if (match) {
       consumedLength = match[0].length;
       string = string.slice(consumedLength);
-      const parsed = parseInt(match[0], 10);
-      if (parsed > Number.MAX_SAFE_INTEGER) {
-        throw new Error("time: bad [0-9]*");
-      }
       return parseInt(match[0], 10);
     }
 
@@ -178,23 +174,11 @@ export const parseDuration = original => {
 
     let value = digit * unit;
 
-    if (value > Number.MAX_SAFE_INTEGER) {
-      throw new TypeError(`time: invalid duration ${original}`);
-    }
-
     if (fraction > 0) {
       value += fraction * (unit / scale);
     }
 
-    if (value > Number.MAX_SAFE_INTEGER) {
-      throw new TypeError(`time: invalid duration ${original}`);
-    }
-
     duration += value;
-
-    if (duration > Number.MAX_SAFE_INTEGER) {
-      throw new TypeError(`time: invalid duration ${original}`);
-    }
   }
 
   return negative ? -duration : duration;

--- a/src/lib/util/date.test.js
+++ b/src/lib/util/date.test.js
@@ -1,0 +1,111 @@
+import {
+  parseDuration,
+  nanosecond,
+  microsecond,
+  millisecond,
+  second,
+  minute,
+  hour,
+} from "./date";
+
+describe("date utils", () => {
+  describe("parseDuration", () => {
+    it("should match go time::parseDuration spec", () => {
+      const parseDurationTests = [
+        // simple
+        ["0", true, 0],
+        ["5s", true, 5 * second],
+        ["30s", true, 30 * second],
+        ["1478s", true, 1478 * second],
+        // sign
+        ["-5s", true, -5 * second],
+        ["+5s", true, 5 * second],
+        ["-0", true, 0],
+        ["+0", true, 0],
+        // decimal
+        ["5.0s", true, 5 * second],
+        ["5.6s", true, 5 * second + 600 * millisecond],
+        ["5.s", true, 5 * second],
+        [".5s", true, 500 * millisecond],
+        ["1.0s", true, 1 * second],
+        ["1.00s", true, 1 * second],
+        ["1.004s", true, 1 * second + 4 * millisecond],
+        ["1.0040s", true, 1 * second + 4 * millisecond],
+        ["100.00100s", true, 100 * second + 1 * millisecond],
+        // different units
+        ["10ns", true, 10 * nanosecond],
+        ["11us", true, 11 * microsecond],
+        ["12µs", true, 12 * microsecond], // U+00B5
+        ["12μs", true, 12 * microsecond], // U+03BC
+        ["13ms", true, 13 * millisecond],
+        ["14s", true, 14 * second],
+        ["15m", true, 15 * minute],
+        ["16h", true, 16 * hour],
+        // composite durations
+        ["3h30m", true, 3 * hour + 30 * minute],
+        ["10.5s4m", true, 4 * minute + 10 * second + 500 * millisecond],
+        ["-2m3.4s", true, -(2 * minute + 3 * second + 400 * millisecond)],
+        [
+          "1h2m3s4ms5us6ns",
+          true,
+          1 * hour +
+            2 * minute +
+            3 * second +
+            4 * millisecond +
+            5 * microsecond +
+            6 * nanosecond,
+        ],
+        [
+          "39h9m14.425s",
+          true,
+          39 * hour + 9 * minute + 14 * second + 425 * millisecond,
+        ],
+        // large value
+        ["52763797000ns", true, 52763797000 * nanosecond],
+        // more than 9 digits after decimal point, see https://golang.org/issue/6617
+        ["0.3333333333333333333h", true, 20 * minute],
+        // 9007199254740993 = 1<<53+1 cannot be stored precisely in a float64
+        // ["9007199254740993ns", true, (1 << (53 + 1)) * nanosecond],
+        // largest duration that can be represented by int64 in nanoseconds
+        // ["9223372036854775807ns", true, (1 << (63 - 1)) * nanosecond],
+        // ["9223372036854775.807us", true, (1 << (63 - 1)) * nanosecond],
+        // ["9223372036s854ms775us807ns", true, (1 << (63 - 1)) * nanosecond],
+        // large negative value
+        // ["-9223372036854775807ns", true, -1 << (63 + 1 * nanosecond)],
+        // huge string; issue 15011.
+        ["0.100000000000000000000h", true, 6 * minute],
+        // This value tests the first overflow check in leadingFraction.
+        // [
+        //   "0.830103483285477580700h",
+        //   true,
+        //   49 * minute + 48 * second + 372539827 * nanosecond,
+        // ],
+
+        // errors
+        ["", false, 0],
+        ["3", false, 0],
+        ["-", false, 0],
+        ["s", false, 0],
+        [".", false, 0],
+        ["-.", false, 0],
+        [".s", false, 0],
+        ["+.s", false, 0],
+        ["3000000h", false, 0], // overflow
+        ["9223372036854775808ns", false, 0], // overflow
+        ["9223372036854775.808us", false, 0], // overflow
+        ["9223372036854ms775us808ns", false, 0], // overflow
+        // largest negative value of type int64 in nanoseconds should fail
+        // see https://go-review.googlesource.com/#/c/2461/
+        ["-9223372036854775808ns", false, 0],
+      ];
+
+      parseDurationTests.forEach(([input, ok, expected]) => {
+        if (ok) {
+          expect([input, parseDuration(input)]).toEqual([input, expected]);
+        } else {
+          expect(() => parseDuration(input)).toThrow();
+        }
+      });
+    });
+  });
+});

--- a/src/lib/util/date.test.js
+++ b/src/lib/util/date.test.js
@@ -90,13 +90,13 @@ describe("date utils", () => {
         ["-.", false, 0],
         [".s", false, 0],
         ["+.s", false, 0],
-        ["3000000h", false, 0], // overflow
-        ["9223372036854775808ns", false, 0], // overflow
-        ["9223372036854775.808us", false, 0], // overflow
-        ["9223372036854ms775us808ns", false, 0], // overflow
+        // ["3000000h", false, 0], // overflow
+        // ["9223372036854775808ns", false, 0], // overflow
+        // ["9223372036854775.808us", false, 0], // overflow
+        // ["9223372036854ms775us808ns", false, 0], // overflow
         // largest negative value of type int64 in nanoseconds should fail
         // see https://go-review.googlesource.com/#/c/2461/
-        ["-9223372036854775808ns", false, 0],
+        // ["-9223372036854775808ns", false, 0],
       ];
 
       parseDurationTests.forEach(([input, ok, expected]) => {

--- a/src/lib/util/date.test.js
+++ b/src/lib/util/date.test.js
@@ -10,7 +10,7 @@ import {
 
 describe("date utils", () => {
   describe("parseDuration", () => {
-    it("should match go time::parseDuration spec", () => {
+    it("should behave like go time.parseDuration", () => {
       const parseDurationTests = [
         // simple
         ["0", true, 0],

--- a/src/lib/util/index.js
+++ b/src/lib/util/index.js
@@ -2,6 +2,7 @@ import "./array";
 import "./authAPI";
 import "./checkStatus";
 import "./compose";
+import "./cron";
 import "./consecutivePairs";
 import "./date";
 import "./fetch";


### PR DESCRIPTION
## What is this change?

Add support for formatting non-standard cron expressions (ex. `@hourly`, `@every 10m` etc.).

Prevent the `CronDescriptor` component from raising an error in the event that a invalid cron expression can not be formatted.

## Why is this change necessary?

Closes #114

## Does your change need a Changelog entry?

Yes. Still TODO

## Do you need clarification on anything?

No

## Were there any complications while making this change?

Parsing `@every <duration>` expressions correctly according to the sensu-go backend (see: https://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules) requires a go `time.parseDuration` compatible implementation in js. A truly compatible implementation isn't possible without a 64 bit int type, so the `parseDuration` function added in this PR implements identical parsing behavior but succumb to floating-point error in _exteme_ cases. For our needs this is a fine compromise as we don't need need large-value nanosecond precision that `time.parseDuration` happens to offer. In any case we don't use this to process any data that is sent to the backend - only to help format values rendered in the IU.

(Note: JS does have a `BigInt` class that would allow us to implement a truly 1:1 `parseDuration` function, but that is beyond unnecessary in this situation 😀)

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Tested by rendering a check with various cron vales.
This PR adds unit tests to cover the cron expression formatter.