### PR TITLE
[Bugfix] Properly display handler timeout

### DIFF
--- a/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsConfiguration.js
+++ b/src/lib/component/partial/HandlerDetailsContainer/HandlerDetailsConfiguration.js
@@ -90,7 +90,13 @@ const HandlerDetailsConfiguration = ({ handler }) => (
               <DictionaryKey>Timeout</DictionaryKey>
               <DictionaryValue>
                 <Maybe value={handler.timeout > 0} fallback="—">
-                  {val => (val ? <Duration duration={val * 1000} /> : "Never")}
+                  {() =>
+                    handler.timeout ? (
+                      <Duration duration={handler.timeout * 1000} />
+                    ) : (
+                      "Never"
+                    )
+                  }
                 </Maybe>
               </DictionaryValue>
             </DictionaryEntry>


### PR DESCRIPTION
## What is this change?

Previously, if a handler's timeout value was greater than 0, the UI would display the timeout as 1 second regardless of the actual value. Is was because we passed `true` to the `Maybe` component's render function when we should actually be using the `handler.timeout` integer value.

<img width="1155" alt="Screen_Shot_2019-05-27_at_2_08_46_PM" src="https://user-images.githubusercontent.com/3856248/58439491-24ee9080-8089-11e9-8e71-14d96988ee78.png">

## Why is this change necessary?
The UI previously displayed the wrong value for Handler Timeouts

## Does your change need a Changelog entry?
No, this view did not previously exist before the current release. 

## How did you verify this change?
Manually. 

