### PR TITLE
Hide scroll bars from CodeBlock elements

### DIFF
--- a/src/lib/component/base/CodeBlock/CodeBlock.js
+++ b/src/lib/component/base/CodeBlock/CodeBlock.js
@@ -7,7 +7,7 @@ import { emphasize } from "/vendor/@material-ui/core/styles/colorManipulator";
 const styles = theme => ({
   root: {
     fontFamily: theme.typography.monospace.fontFamily,
-    overflowX: "scroll",
+    overflowX: "auto",
     userSelect: "text",
     tabSize: 2,
     color:


### PR DESCRIPTION
## What is this change?

This change updates the CodeBlock styles to use `overflow-x: auto` instead of `overflow-x: scroll` in order to hide unnecessary scroll bars from our CodeBlock elements.

<img width="1065" alt="Screen Shot 2019-05-28 at 4 43 32 PM" src="https://user-images.githubusercontent.com/3856248/58519287-bfbd9c80-8167-11e9-9666-782a53c90ca8.png">


## Why is this change necessary?
Closes https://github.com/sensu/sensu-enterprise-go/issues/297

## Does your change need a Changelog entry?
Nope.

## How did you verify this change?
Manually. 
1. Use a mouse.
2. Create a check with a short command. (eg. echo 'hi')
3. Logon to web.
4. Navigate to the check that you created in step two.
5. Observe the scrollbar.