### PR TITLE
Avoid blindly sending user to 'default' namespace

### DIFF
--- a/src/lib/apollo/resolvers/lastNamespace.graphql
+++ b/src/lib/apollo/resolvers/lastNamespace.graphql
@@ -1,6 +1,6 @@
 extend type Query {
   "The last namespace that the client accessed."
-  lastNamespace: String!
+  lastNamespace: String
 }
 
 extend type Mutation {

--- a/src/lib/apollo/resolvers/lastNamespace.js
+++ b/src/lib/apollo/resolvers/lastNamespace.js
@@ -1,6 +1,6 @@
 export default {
   defaults: {
-    lastNamespace: "default",
+    lastNamespace: null,
   },
   resolvers: {
     Mutation: {


### PR DESCRIPTION
## What is this change?

Avoid blindly redirecting our users to 'default' namespace, when `lastNamespace` is not unset.

## Why is this change necessary?

Closes #30 

## Does your change need a Changelog entry?

Yup.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

No.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

None required.

## How did you verify this change?

Manual.