### PR TITLE
Add `material-ui-chip-input` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "killable": "^1.0.0",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.11",
+    "material-ui-chip-input": "^1.0.0-beta.17",
     "modernizr": "^3.6.0",
     "prettier": "^1.16.4",
     "prop-types": "^15.6.0",

--- a/src/vendor/@material-ui-chip-input.js
+++ b/src/vendor/@material-ui-chip-input.js
@@ -1,0 +1,2 @@
+export { default } from "material-ui-chip-input";
+export * from "material-ui-chip-input";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5943,6 +5943,14 @@ markdown-it@^8.4.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+material-ui-chip-input@^1.0.0-beta.17:
+  version "1.0.0-beta.17"
+  resolved "https://registry.yarnpkg.com/material-ui-chip-input/-/material-ui-chip-input-1.0.0-beta.17.tgz#a6d31c89e495a3d5f608f6d155670d682e08f744"
+  integrity sha512-P/1mofZ9JtuCepxn1E2o3DH+Jf/dwqi/trQ4KsWZkXxk8KFQsDg7GZTmx/mX+4mbllnpyRz5la+8WIBeKuvU4Q==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.1"
+
 md5.js@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
@@ -7176,7 +7184,7 @@ prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
## What is this change?

This change adds [`material-ui-chip-input`](https://github.com/TeamWertarbyte/material-ui-chip-input#readme) as a dependency for the web application to support filtering enhancements in the enterprise version of the application.

## Why is this change necessary?
Supports sensu/sensu-enterprise-go#470 by adding a library that handles chip input and chip rendering.

## Does your change need a Changelog entry?
No.

## How did you verify this change?
Manually, by importing the vendor'd version of the library and attempting to render it in a component. 

```
import ChipInput from "/vendor/@material-ui-chip-input";
```