### PR TITLE
Replace named type exports with wildcard export

### DIFF
--- a/src/lib/component/util/QueryParams/index.tsx
+++ b/src/lib/component/util/QueryParams/index.tsx
@@ -1,2 +1,3 @@
-export { default, QueryParamsUpdater, QueryParamsMap } from "./QueryParams";
+export { default } from "./QueryParams";
+export * from "./QueryParams";
 export { default as withQueryParams } from "./withQueryParams";

--- a/src/lib/component/util/index.tsx
+++ b/src/lib/component/util/index.tsx
@@ -1,12 +1,8 @@
 export { default as ConditionalRoute } from "./ConditionalRoute";
 export { default as CurrentDateProvider } from "./CurrentDateProvider";
 export { default as Maybe } from "./Maybe";
-export {
-  default as QueryParams,
-  withQueryParams,
-  QueryParamsUpdater,
-  QueryParamsMap,
-} from "./QueryParams";
+export { default as QueryParams } from "./QueryParams";
+export * from "./QueryParams";
 export { default as WithWidth, isWidthUp } from "./WithWidth";
 export { default as createStyledComponent } from "./createStyledComponent";
 export { default as AuthInvalidRoute } from "./AuthInvalidRoute";


### PR DESCRIPTION
## What is this change?

Babel does not allow re-exporting imported TypeScript types since it forces the `isolatedModules` flag. The workaround is to use wildcard exports which allows TypeScript to resolve the types but prevents babel from trying to do so.

see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
see: https://github.com/Microsoft/TypeScript/issues/21194

## Why is this change necessary?

Fixes this problem:
![image](https://user-images.githubusercontent.com/1074748/59304772-bfd09880-8c4d-11e9-92ca-0f48e2a81e6b.png)


## Does your change need a Changelog entry?

No.

## Do you need clarification on anything?

No.

## Were there any complications while making this change?

Replacing named exports with wildcard exports more-or-less widens the shared namespace. Care must be taken to ensure that all exports from a file targeted with `export * from` have non-conflicting names.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No.

## How did you verify this change?

Manually tested the vendored package.