### PR TITLE
Bump GraphQL Schema Ref to 92fa1ee

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,5 +195,5 @@
     "graphql-config/**/graphql": "0.13.0",
     "graphql-import/**/graphql": "0.13.0"
   },
-  "graphQLSchemaRef": "665301b"
+  "graphQLSchemaRef": "92fa1ee"
 }


### PR DESCRIPTION
## Summary
This change bumps the GraphQL Schema Ref to `92fa1ee` to include the latest schema changes from https://github.com/sensu/sensu-go/pull/3049

## Why is this change necessary?
This change supports a [bug fix Sensu Enterprise](https://github.com/sensu/sensu-enterprise-go/issues/496)

## How did you verify this change?
Manually, by inspecting the schema files generated by running `yarn` locally. 
