### PR TITLE
Re-add 'apollo-link-context' dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "postinstall": "yarn fetch-schema"
   },
   "dependencies": {
-    "@sensuapp/eslint-plugin": "link:./config/eslint-plugin",
     "@10xjs/date-input-controller": "0.1.6",
     "@10xjs/form": "^0.1.7",
     "@babel/core": "^7.0.0",
@@ -62,6 +61,7 @@
     "@material-ui/icons": "^3.0.0",
     "@octokit/plugin-throttling": "^2.4.0",
     "@octokit/rest": "^16.23.2",
+    "@sensuapp/eslint-plugin": "link:./config/eslint-plugin",
     "@testing-library/react": "^8.0.1",
     "@types/classnames": "^2.2.7",
     "@types/es6-error": "^4.0.2",
@@ -76,6 +76,7 @@
     "apollo-client": "^2.6.2",
     "apollo-link": "^1.2.11",
     "apollo-link-batch-http": "^1.2.11",
+    "apollo-link-context": "^1.0.18",
     "autoprefixer": "^7.1.2",
     "aws-sdk": "^2.437.0",
     "babel-eslint": "^10.0.1",

--- a/src/lib/apollo/client.tsx
+++ b/src/lib/apollo/client.tsx
@@ -8,10 +8,11 @@ import {
   IntrospectionResultData,
 } from "/vendor/apollo-cache-inmemory";
 import ApolloClient from "/vendor/apollo-client";
+import { setContext } from "/vendor/apollo-link-context";
 
-import createHttpLink from "./httpLink";
-import createIntrospectionLink from "./introspectionLink";
-import createTokenRefreshLink from "./tokenRefreshLink";
+import httpLink from "./httpLink";
+import introspectionLink from "./introspectionLink";
+import tokenRefreshLink from "./tokenRefreshLink";
 import createStateLink from "./stateLink";
 import localStorageSync from "./localStorageSync";
 
@@ -81,13 +82,19 @@ const createClient = ({
     defaults: clientState.defaults,
   });
 
+  const contextLink = setContext(() => ({
+    getClient,
+    introspectionURL,
+  }));
+
   client = new ApolloClient({
     cache,
     link: ApolloLink.from([
-      createIntrospectionLink(introspectionURL),
-      createTokenRefreshLink(getClient),
+      contextLink,
+      introspectionLink,
+      tokenRefreshLink,
       ...link,
-      createHttpLink(),
+      httpLink,
     ]),
     resolvers: clientState.resolvers,
   });

--- a/src/lib/apollo/introspectionLink.js
+++ b/src/lib/apollo/introspectionLink.js
@@ -7,35 +7,35 @@ import { ApolloLink, Observable } from "/vendor/apollo-link";
  * In practice this means the apollo dev tools can not only display the server's
  * schema but any additions the client has made.
  */
-export default introspectionUrl =>
-  new ApolloLink((operation, forward) => {
-    const { operationName } = operation;
+export default new ApolloLink((operation, forward) => {
+  const { operationName } = operation;
+  const { introspectionURL } = operation.getContext();
 
-    // This is maybe not the most ideal heuristic but the alternative is
-    // comparing the given query with the static one included in graphql-js.
-    // The query is very large and liable to be brittle as it changes between
-    // versions.
-    //
-    // Works with apollo dev tools aand GraphiQL as they always include the
-    // operationName.
-    if (operationName !== "IntrospectionQuery") {
-      return forward(operation);
-    }
+  // This is maybe not the most ideal heuristic but the alternative is
+  // comparing the given query with the static one included in graphql-js.
+  // The query is very large and liable to be brittle as it changes between
+  // versions.
+  //
+  // Works with apollo dev tools aand GraphiQL as they always include the
+  // operationName.
+  if (operationName !== "IntrospectionQuery") {
+    return forward(operation);
+  }
 
-    return new Observable(obs => {
-      fetch(introspectionUrl)
-        .then(response => {
-          operation.setContext({ response });
-          return response;
-        })
-        .then(response => response.json())
-        .then(response => {
-          obs.next(response);
-          obs.complete();
-          return response;
-        })
-        .catch(err => obs.error(err));
+  return new Observable(obs => {
+    fetch(introspectionURL)
+      .then(response => {
+        operation.setContext({ response });
+        return response;
+      })
+      .then(response => response.json())
+      .then(response => {
+        obs.next(response);
+        obs.complete();
+        return response;
+      })
+      .catch(err => obs.error(err));
 
-      return () => {};
-    });
+    return () => {};
   });
+});

--- a/src/lib/apollo/tokenRefreshLink.js
+++ b/src/lib/apollo/tokenRefreshLink.js
@@ -10,67 +10,68 @@ import refreshTokens from "/lib/mutation/refreshTokens";
 const EXPIRY_THRESHOLD_MS = 13 * 60 * 1000;
 const MAX_REFRESHES = 3;
 
-const tokenRefreshLink = getClient =>
-  new ApolloLink((operation, forward) => {
-    return new Observable(observer => {
-      let sub;
+const tokenRefreshLink = new ApolloLink((operation, forward) => {
+  const { getClient } = operation.getContext();
 
-      const fetchToken = (attempts = 0) => {
-        const forceRefresh = attempts > 0;
+  return new Observable(observer => {
+    let sub;
 
-        refreshTokens(getClient(), {
-          notBefore: forceRefresh
-            ? null
-            : new Date(Date.now() + EXPIRY_THRESHOLD_MS).toISOString(),
-        })
-          .then(
-            ({ data }) => {
-              const { auth } = data.refreshTokens;
+    const fetchToken = (attempts = 0) => {
+      const forceRefresh = attempts > 0;
 
-              operation.setContext({
-                headers: {
-                  Authorization: `Bearer ${auth.accessToken}`,
-                },
-              });
+      refreshTokens(getClient(), {
+        notBefore: forceRefresh
+          ? null
+          : new Date(Date.now() + EXPIRY_THRESHOLD_MS).toISOString(),
+      })
+        .then(
+          ({ data }) => {
+            const { auth } = data.refreshTokens;
 
-              const nextObserver = {
-                next: observer.next.bind(observer),
-                complete: observer.complete.bind(observer),
+            operation.setContext({
+              headers: {
+                Authorization: `Bearer ${auth.accessToken}`,
+              },
+            });
 
-                // If chain results in an unauthorized error being thrown,
-                // either attempt to create a new access token or flag the
-                // auth token pair as invalid and throw query aborted err.
-                error: err => {
-                  if (err instanceof UnauthorizedError) {
-                    if (attempts < MAX_REFRESHES && !auth.invalid) {
-                      sub.unsubscribe();
-                      fetchToken(attempts + 1);
-                    } else {
-                      flagTokens(getClient());
-                      observer.error(new QueryAbortedError(err));
-                    }
+            const nextObserver = {
+              next: observer.next.bind(observer),
+              complete: observer.complete.bind(observer),
+
+              // If chain results in an unauthorized error being thrown,
+              // either attempt to create a new access token or flag the
+              // auth token pair as invalid and throw query aborted err.
+              error: err => {
+                if (err instanceof UnauthorizedError) {
+                  if (attempts < MAX_REFRESHES && !auth.invalid) {
+                    sub.unsubscribe();
+                    fetchToken(attempts + 1);
                   } else {
-                    observer.error(err);
+                    flagTokens(getClient());
+                    observer.error(new QueryAbortedError(err));
                   }
-                },
-              };
-              sub = forward(operation).subscribe(nextObserver);
-            },
-            when(UnauthorizedError, error => {
-              throw new QueryAbortedError(error);
-            }),
-          )
-          .catch(observer.error.bind(observer));
-      };
+                } else {
+                  observer.error(err);
+                }
+              },
+            };
+            sub = forward(operation).subscribe(nextObserver);
+          },
+          when(UnauthorizedError, error => {
+            throw new QueryAbortedError(error);
+          }),
+        )
+        .catch(observer.error.bind(observer));
+    };
 
-      fetchToken();
+    fetchToken();
 
-      return () => {
-        if (sub) {
-          sub.unsubscribe();
-        }
-      };
-    });
+    return () => {
+      if (sub) {
+        sub.unsubscribe();
+      }
+    };
   });
+});
 
 export default tokenRefreshLink;

--- a/src/vendor/apollo-link-context.tsx
+++ b/src/vendor/apollo-link-context.tsx
@@ -1,0 +1,2 @@
+export { default } from "apollo-link-context";
+export * from "apollo-link-context";

--- a/src/vendor/index.tsx
+++ b/src/vendor/index.tsx
@@ -9,6 +9,7 @@ import "./apollo-cache-inmemory";
 import "./apollo-client";
 import "./apollo-link";
 import "./apollo-link-batch-http";
+import "./apollo-link-context";
 import "./classnames";
 import "./cronstrue";
 import "./deepmerge";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,6 +1539,14 @@ apollo-link-batch@^1.1.12:
     apollo-link "^1.2.11"
     tslib "^1.9.3"
 
+apollo-link-context@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.18.tgz#9e700e3314da8ded50057fee0a18af2bfcedbfc3"
+  integrity sha512-aG5cbUp1zqOHHQjAJXG7n/izeMQ6LApd/whEF5z6qZp5ATvcyfSNkCfy3KRJMMZZ3iNfVTs6jF+IUA8Zvf+zeg==
+  dependencies:
+    apollo-link "^1.2.12"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz#c688f6baaffdc7b269b2db7ae89dae7c58b5b350"
@@ -1565,6 +1573,16 @@ apollo-link@^1.2.11:
     ts-invariant "^0.3.2"
     tslib "^1.9.3"
     zen-observable-ts "^0.8.18"
+
+apollo-link@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.12.tgz#014b514fba95f1945c38ad4c216f31bcfee68429"
+  integrity sha512-fsgIAXPKThyMVEMWQsUN22AoQI+J/pVXcjRGAShtk97h7D8O+SPskFinCGEkxPeQpE83uKaqafB2IyWdjN+J3Q==
+  dependencies:
+    apollo-utilities "^1.3.0"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.19"
 
 apollo-utilities@1.3.2, apollo-utilities@^1.3.2:
   version "1.3.2"
@@ -8233,6 +8251,14 @@ zen-observable-ts@^0.8.18:
   version "0.8.18"
   resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz#ade44b1060cc4a800627856ec10b9c67f5f639c8"
   integrity sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==
+  dependencies:
+    tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+zen-observable-ts@^0.8.19:
+  version "0.8.19"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
+  integrity sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==
   dependencies:
     tslib "^1.9.3"
     zen-observable "^0.8.0"


### PR DESCRIPTION
## What is this change?

https://github.com/sensu/web/pull/144 removes the `apollo-link-context` dependency from our Apollo Client implementation, but it breaks our Apollo Link contract in Sensu Enterprise.

The goal of this ticket is to re-implement `apollo-link-context`, so that our Apollo Links can retrieve the client from context.

## Why is this change necessary?
Right now, if we attempt to vendor in the latest changes from sensu/web, the Enterprise Web app crashes.

Supports https://github.com/sensu/sensu-enterprise-go/issues/523

## How did you verify this change?
Manually. 
