### PR TITLE
Update `parseFilter` logic to allow for ":" values

### DIFF
--- a/src/lib/util/filterParams.tsx
+++ b/src/lib/util/filterParams.tsx
@@ -16,8 +16,11 @@ export type FilterMap = Record<string, string>;
 export type FilterArray = Filter[];
 
 export const parseFilter = (param: string): FilterTuple => {
-  const pair = param.split(separator, 2);
-  return pair.slice(0, 2) as FilterTuple;
+  const pos = param.indexOf(separator);
+  if (pos === -1) {
+    return [param, ""];
+  }
+  return [param.slice(0, pos), param.slice(pos + 1)];
 };
 
 export const parseFilterParams = (params: string[] | string = []): FilterMap =>


### PR DESCRIPTION
## What is this change?
This change updates the `parseFilter` implementation in `lib/util/filterParams.tsx` to allow filter values to include ":" values. The previous implementation used `String.split()` which discards the other split values in the string. 

This implementation looks for the first ":" separator, and splits the key and value, retaining the rest of the value even if it includes ":".

## Why is this change necessary?
Closes https://github.com/sensu/sensu-enterprise-go/issues/529

## How did you verify this change?
Manual
