### PR TITLE
Create a list view for the 'Event Filters' resource type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,5 +196,5 @@
     "graphql-config/**/graphql": "0.13.0",
     "graphql-import/**/graphql": "0.13.0"
   },
-  "graphQLSchemaRef": "0eca3ef"
+  "graphQLSchemaRef": "c80ddea"
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -25,6 +25,7 @@ import {
   CheckIcon,
   EntityIcon,
   EventIcon,
+  EventFilterIcon,
   HandlerIcon,
   SilenceIcon,
 } from "/lib/component/icon";
@@ -35,6 +36,7 @@ import {
   ChecksView,
   EntitiesView,
   EventsView,
+  EventFiltersView,
   HandlersView,
   SilencesView,
   NotFoundView,
@@ -89,6 +91,11 @@ const renderApp = () => {
                       caption: "Checks",
                     },
                     {
+                      to: `${props.match.url}/filters`,
+                      icon: EventFilterIcon,
+                      caption: "Filters",
+                    },
+                    {
                       to: `${props.match.url}/handlers`,
                       icon: HandlerIcon,
                       caption: "Handlers",
@@ -137,6 +144,10 @@ const renderApp = () => {
                     <Route
                       path={`${props.match.path}/events`}
                       component={EventsView}
+                    />
+                    <Route
+                      path={`${props.match.path}/filters`}
+                      component={EventFiltersView}
                     />
                     <Route
                       path={`${props.match.path}/handlers`}

--- a/src/lib/component/icon/index.js
+++ b/src/lib/component/icon/index.js
@@ -12,6 +12,7 @@ export { default as DonutSmallIcon } from "@material-ui/icons/DonutSmall";
 export { default as EmoticonIcon } from "@material-ui/icons/InsertEmoticon";
 export { default as EntityIcon } from "@material-ui/icons/DesktopMac";
 export { default as EventIcon } from "@material-ui/icons/Notifications";
+export { default as EventFilterIcon } from "@material-ui/icons/FilterList";
 export { default as ExpandMoreIcon } from "@material-ui/icons/ExpandMore";
 export { default as ExploreIcon } from "@material-ui/icons/Explore";
 export { default as EyeIcon } from "@material-ui/icons/RemoveRedEye";

--- a/src/lib/component/partial/EventFiltersList/EventFiltersList.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersList.tsx
@@ -1,0 +1,159 @@
+import React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "/vendor/@material-ui/core";
+
+import { useSearchParams, useFilterParams } from "/lib/component/util";
+import { ListController } from "/lib/component/controller";
+import { Loader, TableListEmptyState } from "/lib/component/base";
+
+import Pagination from "/lib/component/partial/Pagination";
+
+import EventFiltersListHeader from "./EventFiltersListHeader";
+import EventFiltersListItem from "./EventFiltersListItem";
+
+export interface EventFiltersListVariables {
+  limit: number;
+  offset: number;
+  order: string;
+  filters: string[];
+}
+
+export const eventFiltersListFragments = {
+  namespace: gql`
+    fragment EventFiltersList_namespace on Namespace {
+      eventFilters(
+        limit: $limit
+        offset: $offset
+        orderBy: $order
+        filters: $filters
+      ) @connection(key: "eventFilters", filter: ["filters", "orderBy"]) {
+        nodes {
+          id
+          name
+          namespace
+          action
+        }
+
+        pageInfo {
+          ...Pagination_pageInfo
+        }
+      }
+    }
+    ${Pagination.fragments.pageInfo}
+  `,
+};
+
+interface EventFilter {
+  id: string;
+  action: string;
+  deleted: boolean;
+  name: string;
+  namespace: string;
+}
+
+interface PageInfo {
+  totalCount: number;
+}
+
+interface Namespace {
+  eventFilters: {
+    pageInfo: PageInfo;
+    nodes: EventFilter[];
+  };
+}
+
+interface Props {
+  editable: boolean;
+  loading: boolean;
+  limit?: number;
+  namespace?: Namespace;
+  offset?: number;
+  order?: string;
+}
+
+const EventFiltersList = ({
+  editable,
+  loading,
+  limit,
+  namespace,
+  offset,
+  order,
+}: Props) => {
+  const [, setParams] = useSearchParams();
+  const [filters, setFilters] = useFilterParams();
+
+  const items: EventFilter[] = namespace
+    ? namespace.eventFilters.nodes.filter((ef: EventFilter) => !ef.deleted)
+    : [];
+
+  return (
+    <ListController
+      items={items}
+      getItemKey={(eventFilter: EventFilter) => eventFilter.id}
+      renderEmptyState={() => {
+        return (
+          <TableRow>
+            <TableCell>
+              <TableListEmptyState
+                loading={loading}
+                primary="No results matched your query."
+                secondary="
+              Try refining your search query in the search box. The filter
+              buttons above are also a helpful way of quickly finding entities.
+            "
+              />
+            </TableCell>
+          </TableRow>
+        );
+      }}
+      renderItem={({ key, item: eventFilter }) => (
+        <EventFiltersListItem key={key} eventFilter={eventFilter} />
+      )}
+    >
+      {({ children }) => (
+        <Paper>
+          <Loader loading={loading}>
+            <EventFiltersListHeader
+              editable={editable}
+              filters={filters}
+              onChangeFilters={setFilters}
+              order={order}
+              rowCount={items.length}
+            />
+
+            <Table>
+              <TableBody>{children}</TableBody>
+            </Table>
+
+            <Pagination
+              limit={limit}
+              offset={offset}
+              pageInfo={namespace && namespace.eventFilters.pageInfo}
+              onChangeQuery={(update: any) =>
+                setParams((params) => ({ ...params, ...update }))
+              }
+            />
+          </Loader>
+        </Paper>
+      )}
+    </ListController>
+  );
+};
+
+EventFiltersList.defaultProps = {
+  editable: false,
+  namespace: null,
+  loading: false,
+  limit: undefined,
+  offset: undefined,
+  filters: { action: "" },
+};
+
+export default EventFiltersList;

--- a/src/lib/component/partial/EventFiltersList/EventFiltersListHeader.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersListHeader.tsx
@@ -1,0 +1,75 @@
+import React from "/vendor/react";
+
+import ToolbarMenu from "/lib/component/partial/ToolbarMenu";
+import { SelectMenuItem } from "/lib/component/partial/ToolbarMenuItems";
+import ListHeader from "/lib/component/partial/ListHeader";
+import ListSortSelector from "/lib/component/partial/ListSortSelector";
+import { ToolbarSelectOption } from "/lib/component/partial/ToolbarSelect";
+
+import {
+  toggleParam,
+  SetFiltersFunc,
+  FilterParamMap,
+} from "/lib/util/filterParams";
+
+const EVENT_FITLER_ACTION_TYPES = [
+  { label: "ALLOW", value: "allow" },
+  { label: "DENY", value: "deny" },
+];
+
+interface Props {
+  editable: boolean;
+  filters: FilterParamMap;
+  onChangeFilters: SetFiltersFunc;
+  order?: string;
+  rowCount: number;
+}
+
+export const EventFiltersListHeader = ({
+  editable,
+  filters,
+  onChangeFilters,
+  order,
+  rowCount,
+}: Props) => {
+  const renderActions: () => React.ReactNode = () => {
+    return (
+      <ToolbarMenu>
+        <ToolbarMenu.Item key="filter-by-action" visible="if-room">
+          <SelectMenuItem
+            title="Action"
+            onChange={toggleParam("action", onChangeFilters)}
+          >
+            <ToolbarSelectOption value={null} />
+            {EVENT_FITLER_ACTION_TYPES.map(({ label, value }) => (
+              <ToolbarSelectOption
+                key={value}
+                value={value}
+                selected={filters.action === value}
+              >
+                {label}
+              </ToolbarSelectOption>
+            ))}
+          </SelectMenuItem>
+        </ToolbarMenu.Item>
+        <ToolbarMenu.Item key="sort" visible="if-room">
+          <ListSortSelector
+            options={[{ label: "Name", value: "NAME" }]}
+            value={order}
+          />
+        </ToolbarMenu.Item>
+      </ToolbarMenu>
+    );
+  };
+
+  return (
+    <ListHeader
+      sticky
+      editable={editable}
+      rowCount={rowCount}
+      renderActions={renderActions}
+    />
+  );
+};
+
+export default EventFiltersListHeader;

--- a/src/lib/component/partial/EventFiltersList/EventFiltersListItem.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersListItem.tsx
@@ -1,0 +1,75 @@
+import React from "/vendor/react";
+import { TableRow } from "/vendor/@material-ui/core";
+
+import { createStyledComponent, NamespaceLink } from "/lib/component/util";
+import ResourceDetails from "/lib/component/partial/ResourceDetails";
+import TableOverflowCell from "/lib/component/partial/TableOverflowCell";
+
+const AllowLabel = (createStyledComponent as any)({
+  name: "EventFilterListItem.AllowLabel",
+  component: "span",
+  styles: (theme: any) => ({
+    color: "white",
+    fontSize: "0.7rem",
+    fontWeight: "bold",
+    backgroundColor: theme.palette.success,
+    padding: theme.spacing.unit / 2,
+  }),
+});
+
+const DenyLabel = (createStyledComponent as any)({
+  name: "EventFilterListItem.DenyLabel",
+  component: "span",
+  styles: (theme: any) => ({
+    color: "white",
+    fontSize: "0.7rem",
+    fontWeight: "bold",
+    backgroundColor: theme.palette.critical,
+    padding: theme.spacing.unit / 2,
+  }),
+});
+
+const renderActionLabel = (action: string) => {
+  switch (action) {
+    case "ALLOW":
+      return <AllowLabel>{action}</AllowLabel>;
+    case "DENY":
+      return <DenyLabel>{action}</DenyLabel>;
+    default:
+      return <strong>{action}</strong>;
+  }
+};
+
+interface Props {
+  eventFilter: {
+    name: string;
+    namespace: string;
+    action: string;
+  };
+}
+
+export const EventFilterListItem = ({ eventFilter }: Props) => {
+  const { name, namespace, action } = eventFilter;
+
+  return (
+    <TableRow>
+      <TableOverflowCell>
+        <ResourceDetails
+          title={
+            <NamespaceLink namespace={namespace} to={`/fitlers/${name}`}>
+              <strong>{name} </strong>
+            </NamespaceLink>
+          }
+          details={
+            <React.Fragment>
+              {`Action: `}
+              {renderActionLabel(action)}
+            </React.Fragment>
+          }
+        />
+      </TableOverflowCell>
+    </TableRow>
+  );
+};
+
+export default EventFilterListItem;

--- a/src/lib/component/partial/EventFiltersList/EventFiltersListToolbar.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersListToolbar.tsx
@@ -1,0 +1,43 @@
+import React from "/vendor/react";
+
+import { ResetMenuItem } from "/lib/component/partial/ToolbarMenuItems";
+import ToolbarMenu from "/lib/component/partial/ToolbarMenu";
+import ListToolbar from "/lib/component/partial/ListToolbar";
+
+interface Props {
+  onClickReset: () => void;
+  toolbarContent: React.ReactNode;
+  toolbarItems: (props: ToolbarItemsProps) => React.ReactNode;
+}
+
+export interface ToolbarItemsProps extends Props {
+  items: [React.ReactNode];
+}
+
+export const EventFiltersToolbar = (props: Props) => {
+  const { onClickReset, toolbarItems, toolbarContent } = props;
+  return (
+    <ListToolbar
+      search={toolbarContent}
+      toolbarItems={(props: Props) => (
+        <ToolbarMenu>
+          {toolbarItems({
+            ...props,
+            items: [
+              <ToolbarMenu.Item key="reset">
+                <ResetMenuItem onClick={onClickReset} />
+              </ToolbarMenu.Item>,
+            ],
+          })}
+        </ToolbarMenu>
+      )}
+    />
+  );
+};
+
+EventFiltersToolbar.defaultProps = {
+  toolbarContent: <React.Fragment />,
+  toolbarItems: ({ items }: ToolbarItemsProps) => items,
+};
+
+export default EventFiltersToolbar;

--- a/src/lib/component/partial/EventFiltersList/index.tsx
+++ b/src/lib/component/partial/EventFiltersList/index.tsx
@@ -1,0 +1,2 @@
+export { default, eventFiltersListFragments } from "./EventFiltersList";
+export { default as EventFiltersListToolbar } from "./EventFiltersListToolbar";

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -25,6 +25,11 @@ export { default as EntityStatusDescriptor } from "./EntityStatusDescriptor";
 export { default as EventDetailsContainer } from "./EventDetailsContainer";
 export { default as EventStatusDescriptor } from "./EventStatusDescriptor";
 export { default as EventsList, EventsListToolbar } from "./EventsList";
+export {
+  default as EventFiltersList,
+  EventFiltersListToolbar,
+  eventFiltersListFragments,
+} from "./EventFiltersList";
 export { default as HandlersList, HandlersListToolbar } from "./HandlersList";
 export { default as HandlerDetailsContainer } from "./HandlerDetailsContainer";
 export { default as Label } from "./Label";

--- a/src/lib/component/view/EventFiltersView.tsx
+++ b/src/lib/component/view/EventFiltersView.tsx
@@ -1,0 +1,171 @@
+import * as React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+import { ApolloError } from "/vendor/apollo-client";
+
+import { PollingDuration } from "/lib/constant";
+import { FailedError } from "/lib/error/FetchError";
+
+import {
+  parseIntParam,
+  parseStringParam,
+  parseArrayParam,
+} from "/lib/util/params";
+
+import {
+  useSearchParams,
+  SearchParamsMap,
+  useQuery,
+  useFilterParams,
+  UseQueryResult,
+  useRouter,
+} from "/lib/component/util";
+import {
+  MobileFullWidthContent,
+  Content,
+  FilterList,
+} from "/lib/component/base";
+import {
+  AppLayout,
+  EventFiltersList,
+  eventFiltersListFragments,
+  EventFiltersListToolbar,
+  NotFound,
+} from "/lib/component/partial";
+import { EventFiltersListVariables } from "/lib/component/partial/EventFiltersList/EventFiltersList";
+
+interface Variables extends EventFiltersListVariables {
+  namespace: string;
+}
+
+export const eventFiltersViewFragments = {
+  namespace: gql`
+    fragment eventFiltersView_namespace on Namespace {
+      ...EventFiltersList_namespace
+    }
+
+    ${eventFiltersListFragments.namespace}
+  `,
+};
+
+const EventFiltersViewQuery = gql`
+  query EventFitlersViewQuery(
+    $namespace: String!
+    $limit: Int
+    $offset: Int
+    $order: EventFilterListOrder
+    $filters: [String!]
+  ) {
+    namespace(name: $namespace) {
+      ...eventFiltersView_namespace
+    }
+  }
+
+  ${eventFiltersViewFragments.namespace}
+`;
+
+export function useEventFiltersViewQueryVariables(): Variables {
+  const [params] = useSearchParams();
+  const limit = parseIntParam(params.limit, 25);
+  const offset = parseIntParam(params.offset, 0);
+  const order = parseStringParam(params.order, "NAME");
+  const filters = parseArrayParam(params.filters);
+
+  const router = useRouter();
+  const namespace = parseStringParam(
+    (router.match.params as any).namespace,
+    "",
+  );
+
+  return {
+    namespace,
+    limit,
+    offset,
+    order,
+    filters,
+  };
+}
+
+interface EventFiltersViewContentProps {
+  toolbarContent: React.ReactNode;
+  toolbarItems?: () => React.ReactNode;
+  query: UseQueryResult<any, any>;
+  variables: Variables;
+}
+
+export const EventFiltersViewContent = ({
+  toolbarContent,
+  toolbarItems,
+  query,
+  variables,
+}: EventFiltersViewContentProps) => {
+  const { aborted, data = {}, networkStatus } = query;
+  // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
+  const loading = networkStatus < 6;
+
+  const [, setParams] = useSearchParams();
+
+  if (!data.namespace && !loading && !aborted) {
+    return <NotFound />;
+  }
+
+  return (
+    <AppLayout namespace={variables.namespace}>
+      <div>
+        <Content marginBottom>
+          <EventFiltersListToolbar
+            onClickReset={() => {
+              setParams(
+                (params): SearchParamsMap => ({
+                  ...params,
+                  filters: undefined,
+                  order: undefined,
+                }),
+              );
+            }}
+            toolbarContent={toolbarContent}
+            toolbarItems={toolbarItems}
+          />
+        </Content>
+        <MobileFullWidthContent>
+          <EventFiltersList
+            editable={false}
+            loading={(loading && !data.namespace) || aborted}
+            limit={variables.limit}
+            namespace={(data || {}).namespace}
+            offset={variables.offset}
+            order={variables.order}
+          />
+        </MobileFullWidthContent>
+      </div>
+    </AppLayout>
+  );
+};
+
+const BoundFilterList = () => {
+  const [filters, setFilters] = useFilterParams();
+  return <FilterList filters={filters} onChange={setFilters} />;
+};
+
+EventFiltersViewContent.defaultProps = {
+  toolbarContent: <BoundFilterList />,
+};
+
+export const EventFiltersView = () => {
+  const variables = useEventFiltersViewQueryVariables();
+
+  const query = useQuery({
+    query: EventFiltersViewQuery,
+    variables,
+    fetchPolicy: "cache-and-network",
+    pollInterval: PollingDuration.short,
+    onError: (error: Error): void => {
+      if ((error as ApolloError).networkError instanceof FailedError) {
+        return;
+      }
+
+      throw error;
+    },
+  });
+
+  return <EventFiltersViewContent query={query} variables={variables} />;
+};

--- a/src/lib/component/view/index.js
+++ b/src/lib/component/view/index.js
@@ -6,6 +6,7 @@ export { default as EventDetailsView } from "./EventDetailsView";
 export { default as HandlerDetailsView } from "./HandlerDetailsView";
 export * from "./MutatorDetailsView";
 export { default as EventsView } from "./EventsView";
+export * from "./EventFiltersView";
 export { default as HandlersView } from "./HandlersView";
 export { default as NamespaceNotFoundView } from "./NamespaceNotFoundView";
 export { default as NotFoundView } from "./NotFoundView";

--- a/src/lib/util/filterParams.tsx
+++ b/src/lib/util/filterParams.tsx
@@ -15,6 +15,9 @@ export type FilterParamKey = string;
 export type FilterParam = string;
 export type FilterTuple = [string, string];
 export type FilterParamMap = { readonly [K in FilterParamKey]?: FilterParam };
+export type SetFiltersFunc = (
+  update: (prevFilters: FilterParamMap) => FilterParamMap,
+) => void;
 
 export const parseFilter = (param: string): FilterTuple => {
   const pos = param.indexOf(SEPARATOR);
@@ -102,7 +105,7 @@ function omit<T extends {}, K extends string>(key: K, target: T): Omit<T, K> {
  */
 export const toggleParam = (
   key: string,
-  setFilters: (update: (prevFilters: FilterParamMap) => FilterParamMap) => void,
+  setFilters: SetFiltersFunc,
 ): ((val?: string | null) => void) => (val) => {
   setFilters(
     (prevFilters: FilterParamMap): FilterParamMap => {


### PR DESCRIPTION
## What is this change?
This change creates a List View for the `Event Filter` resource type. 

![2019-06-26 14 53 47](https://user-images.githubusercontent.com/3856248/60219573-c8b59280-9827-11e9-9fee-8f315db33526.gif)


## Why is this change necessary?
Closes https://github.com/sensu/sensu-enterprise-go/issues/507
> The goal of this issue is to create List View for the Filters similar to that of our other resources (Checks, Handlers, Entities, etc.).
>
> *Requirements*
>
> - Create a new route for `/:namespace/filters`
> - Fetch a paginated list of Filter resources from the namespace.filters GraphQL field
> - Display a paginated list of Filter resources
> - A navigation link should be added in the sidebar and menu to navigate to this view.
> - Each line item in the list should include the Filter name and the Filter action
> - The list should be sortable by name (`asc`/`desc`) and action (`allow`/`deny`)

## How did you verify this change?
Manually. 

To manually verify this change you can run the `sensu-backend` and the web application locally then, navigate to `http://localhost:3001/:namespace/filters` on the web application

1. Run a `sensu-backend` locally
2. Create a number of event filters. I did this using `sensuctl -create --file example_event_filters.json`
3. Run the sensu/web application locally and navigate to `http://localhost:3001/:namespace/filters`
