### PR TITLE
Create the Event Filter Details view

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -42,6 +42,7 @@ import {
   NotFoundView,
   CheckDetailsView,
   EventDetailsView,
+  EventFilterDetailsView,
   EntityDetailsView,
   HandlerDetailsView,
   MutatorDetailsView,
@@ -120,6 +121,10 @@ const renderApp = () => {
                     <Route
                       path={`${props.match.path}/events/:entity/:check`}
                       component={EventDetailsView}
+                    />
+                    <Route
+                      path={`${props.match.path}/filters/:filter`}
+                      component={EventFilterDetailsView}
                     />
                     <Route
                       path={`${props.match.path}/entities/:entity`}

--- a/src/lib/apollo/resolvers/deleted.graphql
+++ b/src/lib/apollo/resolvers/deleted.graphql
@@ -13,6 +13,11 @@ extend type Event {
   deleted: Boolean!
 }
 
+extend type EventFilter {
+  "Describes whether the EventFilter has been deleted from the system"
+  deleted: Boolean!
+}
+
 extend type Handler {
   "Describes whether the handler has been deleted from the system"
   deleted: Boolean!

--- a/src/lib/apollo/stateLink.js
+++ b/src/lib/apollo/stateLink.js
@@ -15,6 +15,7 @@ export default resolvers =>
     addDeletedFieldTo("CheckConfig"),
     addDeletedFieldTo("Entity"),
     addDeletedFieldTo("Event"),
+    addDeletedFieldTo("EventFilter"),
     addDeletedFieldTo("Handler"),
     addDeletedFieldTo("Mutator"),
     addDeletedFieldTo("Silenced"),

--- a/src/lib/component/base/CodeHighlight/CodeHighlight.js
+++ b/src/lib/component/base/CodeHighlight/CodeHighlight.js
@@ -25,7 +25,8 @@ function postMessage(msg, callback) {
 
 class CodeHighlight extends React.Component {
   static propTypes = {
-    language: PropTypes.oneOf(["json", "bash", "properties"]).isRequired,
+    language: PropTypes.oneOf(["javascript", "json", "bash", "properties"])
+      .isRequired,
     code: PropTypes.string.isRequired,
     component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   };

--- a/src/lib/component/base/CodeHighlight/CodeHighlight.worker.js
+++ b/src/lib/component/base/CodeHighlight/CodeHighlight.worker.js
@@ -1,9 +1,11 @@
 import hljs from "highlight.js/lib/highlight";
 import bash from "highlight.js/lib/languages/bash";
+import javascript from "highlight.js/lib/languages/javascript";
 import json from "highlight.js/lib/languages/json";
 import properties from "highlight.js/lib/languages/properties";
 
 hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("javascript", javascript);
 hljs.registerLanguage("json", json);
 hljs.registerLanguage("properties", properties);
 

--- a/src/lib/component/partial/EntitiesList/EntitiesListHeader.js
+++ b/src/lib/component/partial/EntitiesList/EntitiesListHeader.js
@@ -22,7 +22,7 @@ class EntitiesListHeader extends React.PureComponent {
     editable: PropTypes.bool.isRequired,
     filters: PropTypes.object.isRequired,
     namespace: PropTypes.object,
-    onChangeFilters: PropTypes.object.isRequired,
+    onChangeFilters: PropTypes.func.isRequired,
     onChangeQuery: PropTypes.func.isRequired,
     onClickClearSilences: PropTypes.func.isRequired,
     onClickDelete: PropTypes.func,

--- a/src/lib/component/partial/EventFilterActionLabel/EventFilterActionLabel.tsx
+++ b/src/lib/component/partial/EventFilterActionLabel/EventFilterActionLabel.tsx
@@ -1,0 +1,40 @@
+import React from "/vendor/react";
+import classnames from "/vendor/classnames";
+import {
+  withStyles,
+  Theme,
+  StyleRulesCallback,
+} from "/vendor/@material-ui/core";
+
+interface Props {
+  action: string;
+  // From withStyles
+  classes: any;
+}
+
+const styles: StyleRulesCallback = (theme: Theme) => ({
+  root: {
+    color: theme.palette.common.white,
+    fontSize: "0.7rem",
+    fontWeight: "bold",
+    padding: theme.spacing.unit / 2,
+    backgroundColor: theme.palette.primary.main,
+  },
+  allow: {
+    backgroundColor: theme.palette.secondary.main,
+  },
+  deny: {
+    backgroundColor: theme.palette.error.main,
+  },
+});
+
+const EventFilterActionLabel = ({ action, classes }: Props) => {
+  const className = classnames(classes.root, {
+    [classes.allow]: action === "ALLOW",
+    [classes.deny]: action === "DENY",
+  });
+
+  return <span className={className}>{action}</span>;
+};
+
+export default withStyles(styles)(EventFilterActionLabel);

--- a/src/lib/component/partial/EventFilterActionLabel/index.tsx
+++ b/src/lib/component/partial/EventFilterActionLabel/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./EventFilterActionLabel";

--- a/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsConfiguration.tsx
+++ b/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsConfiguration.tsx
@@ -1,0 +1,128 @@
+import React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import {
+  Card,
+  CardContent,
+  Divider,
+  Grid,
+  Typography,
+} from "/vendor/@material-ui/core";
+
+import {
+  CodeBlock,
+  CodeHighlight,
+  Dictionary,
+  DictionaryKey,
+  DictionaryValue,
+  DictionaryEntry,
+} from "/lib/component/base";
+
+import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
+
+interface EventFilterDetailsConfigurationProps {
+  eventFilter: {
+    name: string;
+    action: string;
+    expressions: string[];
+    runtimeAssets: string[];
+  };
+}
+
+const EventFilterDetailsConfiguration = ({
+  eventFilter,
+}: EventFilterDetailsConfigurationProps) => (
+  <Card>
+    <CardContent>
+      <Typography variant="h5" gutterBottom>
+        Filter Configuration
+      </Typography>
+      <Grid container spacing={0}>
+        <Grid item xs={12} sm={6}>
+          <Dictionary>
+            <DictionaryEntry>
+              <DictionaryKey>Name</DictionaryKey>
+              <DictionaryValue>{eventFilter.name}</DictionaryValue>
+            </DictionaryEntry>
+            <DictionaryEntry>
+              <DictionaryKey>Action</DictionaryKey>
+              <DictionaryValue>
+                <CodeHighlight language="bash" code={eventFilter.action} />
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+    <Divider />
+    <CardContent>
+      <Grid container spacing={0}>
+        <Grid item xs={12}>
+          <Dictionary>
+            <DictionaryEntry fullWidth={!!eventFilter.expressions}>
+              <DictionaryKey>Expressions</DictionaryKey>
+              <DictionaryValue>
+                {eventFilter.expressions &&
+                eventFilter.expressions.length > 0 ? (
+                  <CodeBlock>
+                    <CodeHighlight
+                      language="json"
+                      code={eventFilter.expressions.join("\n")}
+                    />
+                  </CodeBlock>
+                ) : (
+                  "None"
+                )}
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+    <Divider />
+    <CardContent>
+      <Grid container spacing={0}>
+        <Grid item xs={12}>
+          <Dictionary>
+            <DictionaryEntry fullWidth={!!eventFilter.runtimeAssets}>
+              <DictionaryKey>Runtime Assets</DictionaryKey>
+              <DictionaryValue>
+                {eventFilter.runtimeAssets &&
+                eventFilter.runtimeAssets.length > 0 ? (
+                  <CodeBlock>
+                    <CodeHighlight
+                      language="properties"
+                      code={eventFilter.runtimeAssets.join("\n")}
+                    />
+                  </CodeBlock>
+                ) : (
+                  "None"
+                )}
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+    <Divider />
+    <LabelsAnnotationsCell resource={eventFilter} />
+  </Card>
+);
+
+EventFilterDetailsConfiguration.fragments = {
+  eventFilter: gql`
+    fragment EventFilterDetailsConfiguration_eventFilter on EventFilter {
+      deleted @client
+      id
+      name
+      action
+      expressions
+      metadata {
+        ...LabelsAnnotationsCell_objectmeta
+      }
+    }
+    ${LabelsAnnotationsCell.fragments.objectmeta}
+  `,
+};
+
+export default EventFilterDetailsConfiguration;

--- a/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsConfiguration.tsx
+++ b/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsConfiguration.tsx
@@ -18,6 +18,7 @@ import {
   DictionaryEntry,
 } from "/lib/component/base";
 
+import EventFilterActionLabel from "/lib/component/partial/EventFilterActionLabel";
 import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
 
 interface EventFilterDetailsConfigurationProps {
@@ -47,7 +48,7 @@ const EventFilterDetailsConfiguration = ({
             <DictionaryEntry>
               <DictionaryKey>Action</DictionaryKey>
               <DictionaryValue>
-                <CodeHighlight language="bash" code={eventFilter.action} />
+                <EventFilterActionLabel action={eventFilter.action} />
               </DictionaryValue>
             </DictionaryEntry>
           </Dictionary>
@@ -66,7 +67,7 @@ const EventFilterDetailsConfiguration = ({
                 eventFilter.expressions.length > 0 ? (
                   <CodeBlock>
                     <CodeHighlight
-                      language="json"
+                      language="javascript"
                       code={eventFilter.expressions.join("\n")}
                     />
                   </CodeBlock>

--- a/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsContainer.tsx
+++ b/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsContainer.tsx
@@ -1,0 +1,51 @@
+import * as React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import { Grid } from "/vendor/@material-ui/core";
+import { Content, Loader } from "/lib/component/base";
+
+import Configuration from "./EventFilterDetailsConfiguration";
+import EventFilterDetailsToolbar, {
+  EventFilterDetailsToolbarProps,
+} from "./EventFilterDetailsToolbar";
+
+interface EventFilterDetailsContainerProps
+  extends EventFilterDetailsToolbarProps {
+  eventFilter: any;
+  loading: boolean;
+}
+
+const EventFilterDetailsContainer = ({
+  eventFilter,
+  loading,
+  toolbarItems,
+}: EventFilterDetailsContainerProps) => (
+  <Loader loading={loading} passthrough>
+    {eventFilter && (
+      <React.Fragment>
+        <Content marginBottom>
+          <EventFilterDetailsToolbar toolbarItems={toolbarItems} />
+        </Content>
+        <Grid container spacing={16}>
+          <Grid item xs={12}>
+            <Configuration eventFilter={eventFilter} />
+          </Grid>
+        </Grid>
+      </React.Fragment>
+    )}
+  </Loader>
+);
+
+export const eventFilterDetailsContainerFragments = {
+  eventFilter: gql`
+    fragment EventFilterDetailsContainer_eventFilter on EventFilter {
+      id
+      deleted @client
+
+      ...EventFilterDetailsConfiguration_eventFilter
+    }
+    ${Configuration.fragments.eventFilter}
+  `,
+};
+
+export default EventFilterDetailsContainer;

--- a/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsToolbar.tsx
+++ b/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsToolbar.tsx
@@ -1,0 +1,17 @@
+import * as React from "/vendor/react";
+
+import Toolbar from "/lib/component/partial/Toolbar";
+import ToolbarMenu from "/lib/component/partial/ToolbarMenu";
+
+export interface EventFilterDetailsToolbarProps {
+  toolbarItems?: (items: any[]) => React.ReactNode;
+}
+
+const EventFilterDetailsToolbar = ({
+  toolbarItems,
+}: EventFilterDetailsToolbarProps) => {
+  const toolbar = toolbarItems ? toolbarItems([]) : [];
+  return <Toolbar right={<ToolbarMenu>{toolbar}</ToolbarMenu>} />;
+};
+
+export default EventFilterDetailsToolbar;

--- a/src/lib/component/partial/EventFilterDetailsContainer/index.tsx
+++ b/src/lib/component/partial/EventFilterDetailsContainer/index.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  eventFilterDetailsContainerFragments,
+} from "./EventFilterDetailsContainer";

--- a/src/lib/component/partial/EventFiltersList/EventFiltersListHeader.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersListHeader.tsx
@@ -12,7 +12,7 @@ import {
   FilterParamMap,
 } from "/lib/util/filterParams";
 
-const EVENT_FITLER_ACTION_TYPES = [
+const EVENT_FILTER_ACTION_TYPES = [
   { label: "ALLOW", value: "allow" },
   { label: "DENY", value: "deny" },
 ];
@@ -41,7 +41,7 @@ export const EventFiltersListHeader = ({
             onChange={toggleParam("action", onChangeFilters)}
           >
             <ToolbarSelectOption value={null} />
-            {EVENT_FITLER_ACTION_TYPES.map(({ label, value }) => (
+            {EVENT_FILTER_ACTION_TYPES.map(({ label, value }) => (
               <ToolbarSelectOption
                 key={value}
                 value={value}

--- a/src/lib/component/partial/EventFiltersList/EventFiltersListItem.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersListItem.tsx
@@ -56,7 +56,7 @@ export const EventFilterListItem = ({ eventFilter }: Props) => {
       <TableOverflowCell>
         <ResourceDetails
           title={
-            <NamespaceLink namespace={namespace} to={`/fitlers/${name}`}>
+            <NamespaceLink namespace={namespace} to={`/filters/${name}`}>
               <strong>{name} </strong>
             </NamespaceLink>
           }

--- a/src/lib/component/partial/EventFiltersList/EventFiltersListItem.tsx
+++ b/src/lib/component/partial/EventFiltersList/EventFiltersListItem.tsx
@@ -1,44 +1,10 @@
 import React from "/vendor/react";
 import { TableRow } from "/vendor/@material-ui/core";
 
-import { createStyledComponent, NamespaceLink } from "/lib/component/util";
+import { NamespaceLink } from "/lib/component/util";
+import EventFilterActionLabel from "/lib/component/partial/EventFilterActionLabel";
 import ResourceDetails from "/lib/component/partial/ResourceDetails";
 import TableOverflowCell from "/lib/component/partial/TableOverflowCell";
-
-const AllowLabel = (createStyledComponent as any)({
-  name: "EventFilterListItem.AllowLabel",
-  component: "span",
-  styles: (theme: any) => ({
-    color: "white",
-    fontSize: "0.7rem",
-    fontWeight: "bold",
-    backgroundColor: theme.palette.success,
-    padding: theme.spacing.unit / 2,
-  }),
-});
-
-const DenyLabel = (createStyledComponent as any)({
-  name: "EventFilterListItem.DenyLabel",
-  component: "span",
-  styles: (theme: any) => ({
-    color: "white",
-    fontSize: "0.7rem",
-    fontWeight: "bold",
-    backgroundColor: theme.palette.critical,
-    padding: theme.spacing.unit / 2,
-  }),
-});
-
-const renderActionLabel = (action: string) => {
-  switch (action) {
-    case "ALLOW":
-      return <AllowLabel>{action}</AllowLabel>;
-    case "DENY":
-      return <DenyLabel>{action}</DenyLabel>;
-    default:
-      return <strong>{action}</strong>;
-  }
-};
 
 interface Props {
   eventFilter: {
@@ -63,7 +29,7 @@ export const EventFilterListItem = ({ eventFilter }: Props) => {
           details={
             <React.Fragment>
               {`Action: `}
-              {renderActionLabel(action)}
+              <EventFilterActionLabel action={action} />
             </React.Fragment>
           }
         />

--- a/src/lib/component/partial/ListHeader/ListHeader.js
+++ b/src/lib/component/partial/ListHeader/ListHeader.js
@@ -54,6 +54,7 @@ class ListHeader extends React.Component {
     renderActions: () => {},
     renderBulkActions: () => {},
     onClickSelect: () => {},
+    selectedCount: 0,
   };
 
   renderCheckbox = () => {

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -25,6 +25,7 @@ export { default as EntityStatusDescriptor } from "./EntityStatusDescriptor";
 export { default as EventDetailsContainer } from "./EventDetailsContainer";
 export { default as EventStatusDescriptor } from "./EventStatusDescriptor";
 export { default as EventsList, EventsListToolbar } from "./EventsList";
+export { default as EventFilterActionLabel } from "./EventFilterActionLabel";
 export {
   default as EventFiltersList,
   EventFiltersListToolbar,

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -30,6 +30,10 @@ export {
   EventFiltersListToolbar,
   eventFiltersListFragments,
 } from "./EventFiltersList";
+export {
+  default as EventFilterDetailsContainer,
+  eventFilterDetailsContainerFragments,
+} from "./EventFilterDetailsContainer";
 export { default as HandlersList, HandlersListToolbar } from "./HandlersList";
 export { default as HandlerDetailsContainer } from "./HandlerDetailsContainer";
 export { default as Label } from "./Label";

--- a/src/lib/component/view/EventFilterDetailsView.tsx
+++ b/src/lib/component/view/EventFilterDetailsView.tsx
@@ -1,0 +1,100 @@
+import * as React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import { ApolloError } from "/vendor/apollo-client";
+import { PollingDuration } from "../../constant";
+import { FailedError } from "/lib/error/FetchError";
+import { useQuery, useRouter, UseQueryResult } from "/lib/component/util";
+
+import {
+  AppLayout,
+  NotFound,
+  EventFilterDetailsContainer,
+  eventFilterDetailsContainerFragments,
+} from "/lib/component/partial";
+
+interface Variables {
+  namespace: string;
+  name: string;
+}
+
+export const eventFilterDetailsViewFragments = {
+  eventFilter: gql`
+    fragment EventFilterDetailsView_eventFilter on EventFilter {
+      id
+      ...EventFilterDetailsContainer_eventFilter
+    }
+
+    ${eventFilterDetailsContainerFragments.eventFilter}
+  `,
+};
+
+const eventFilterDetailsViewQuery = gql`
+  query EventFilterDetailsContentQuery($namespace: String!, $name: String!) {
+    eventFilter(namespace: $namespace, name: $name) {
+      ...EventFilterDetailsView_eventFilter
+    }
+  }
+  ${eventFilterDetailsViewFragments.eventFilter}
+`;
+
+export function useEventFilterDetailsViewQueryVariables(): Variables {
+  const router = useRouter();
+  const namespace = (router.match.params as any).namespace || "";
+  const name = (router.match.params as any).filter || "";
+
+  return {
+    namespace,
+    name,
+  };
+}
+
+interface EventFilterDetailsViewContentProps {
+  toolbarItems?: (items: any[]) => React.ReactNode;
+  query: UseQueryResult<any, any>;
+  variables: Variables;
+}
+
+export const EventFilterDetailsViewContent = ({
+  toolbarItems,
+  query,
+  variables,
+}: EventFilterDetailsViewContentProps) => {
+  const { aborted, data = {}, networkStatus } = query;
+
+  // see: https://github.com/apollographql/apollo-client/blob/master/packages/apollo-client/src/core/networkStatus.ts
+  const loading = networkStatus < 6;
+
+  if (!loading && !aborted && (!data.eventFilter || data.eventFilter.deleted)) {
+    return <NotFound />;
+  }
+
+  return (
+    <AppLayout namespace={variables.namespace}>
+      <EventFilterDetailsContainer
+        toolbarItems={toolbarItems}
+        eventFilter={data.eventFilter}
+        loading={loading || aborted}
+      />
+    </AppLayout>
+  );
+};
+
+export const EventFilterDetailsView = () => {
+  const variables = useEventFilterDetailsViewQueryVariables();
+  const query = useQuery({
+    query: eventFilterDetailsViewQuery,
+    variables,
+    fetchPolicy: "cache-and-network",
+    pollInterval: PollingDuration.short,
+    onError: (error: Error): void => {
+      if ((error as ApolloError).networkError instanceof FailedError) {
+        return;
+      }
+
+      throw error;
+    },
+  });
+
+  return <EventFilterDetailsViewContent query={query} variables={variables} />;
+};

--- a/src/lib/component/view/EventFiltersView.tsx
+++ b/src/lib/component/view/EventFiltersView.tsx
@@ -48,7 +48,7 @@ export const eventFiltersViewFragments = {
 };
 
 const EventFiltersViewQuery = gql`
-  query EventFitlersViewQuery(
+  query EventFiltersViewQuery(
     $namespace: String!
     $limit: Int
     $offset: Int

--- a/src/lib/component/view/index.js
+++ b/src/lib/component/view/index.js
@@ -3,6 +3,7 @@ export * from "./ChecksView";
 export { default as EntitiesView } from "./EntitiesView";
 export { default as EntityDetailsView } from "./EntityDetailsView";
 export { default as EventDetailsView } from "./EventDetailsView";
+export * from "./EventFilterDetailsView";
 export { default as HandlerDetailsView } from "./HandlerDetailsView";
 export * from "./MutatorDetailsView";
 export { default as EventsView } from "./EventsView";


### PR DESCRIPTION
## What is this change?
This change adds the `/:namespace/filters/:filter` route to the application so that users can view the configuration of an Event Filter resource. 

![2019-06-27 16 26 16](https://user-images.githubusercontent.com/3856248/60307183-5fea1b00-98f8-11e9-8001-5d99046f4929.gif)

## Why is this change necessary?
Closes https://github.com/sensu/sensu-enterprise-go/issues/514

>The goal of this ticket is to create a `FiltersDetailsView` that allows users to view the configuration of a Filter resource.
> 
> **Requirements**
>  - Create a route at `/:namespace/filters/:filterName`
>  - Using the GraphQL `filters` field on the top level `Query` object, fetch a Filter given a `namespace` and a `filterName`. 
>  - Render the configuration of the Filter in the details view. (Filter Name, Namespace, Action, Assets, Filter Expressions, Labels, and Annotations)

## How did you verify this change?
Manually. 

To manually verify this change you can run the `sensu-backend` and the web application locally then, navigate to `http://localhost:3001/:namespace/filters` on the web application

1. Run a `sensu-backend` locally
2. Create a number of event filters. I did this using `sensuctl -create --file example_event_filters.json`
3. Run the sensu/web application locally and navigate to `http://localhost:3001/:namespace/filters/:filter_name`