### PR TITLE
Add Runtime Assets to the Event FilterDetails view

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,5 +196,5 @@
     "graphql-config/**/graphql": "0.13.0",
     "graphql-import/**/graphql": "0.13.0"
   },
-  "graphQLSchemaRef": "c80ddea"
+  "graphQLSchemaRef": "8c6d556"
 }

--- a/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsConfiguration.tsx
+++ b/src/lib/component/partial/EventFilterDetailsContainer/EventFilterDetailsConfiguration.tsx
@@ -20,95 +20,77 @@ import {
 
 import EventFilterActionLabel from "/lib/component/partial/EventFilterActionLabel";
 import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
+import RuntimeAssetsCell, {
+  RuntimeAsset,
+} from "/lib/component/partial/RuntimeAssetsCell";
 
 interface EventFilterDetailsConfigurationProps {
   eventFilter: {
     name: string;
     action: string;
     expressions: string[];
-    runtimeAssets: string[];
+    runtimeAssets: RuntimeAsset[];
   };
 }
 
 const EventFilterDetailsConfiguration = ({
   eventFilter,
-}: EventFilterDetailsConfigurationProps) => (
-  <Card>
-    <CardContent>
-      <Typography variant="h5" gutterBottom>
-        Filter Configuration
-      </Typography>
-      <Grid container spacing={0}>
-        <Grid item xs={12} sm={6}>
-          <Dictionary>
-            <DictionaryEntry>
-              <DictionaryKey>Name</DictionaryKey>
-              <DictionaryValue>{eventFilter.name}</DictionaryValue>
-            </DictionaryEntry>
-            <DictionaryEntry>
-              <DictionaryKey>Action</DictionaryKey>
-              <DictionaryValue>
-                <EventFilterActionLabel action={eventFilter.action} />
-              </DictionaryValue>
-            </DictionaryEntry>
-          </Dictionary>
+}: EventFilterDetailsConfigurationProps) => {
+  const { name, action, expressions, runtimeAssets } = eventFilter;
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h5" gutterBottom>
+          Filter Configuration
+        </Typography>
+        <Grid container spacing={0}>
+          <Grid item xs={12} sm={6}>
+            <Dictionary>
+              <DictionaryEntry>
+                <DictionaryKey>Name</DictionaryKey>
+                <DictionaryValue>{name}</DictionaryValue>
+              </DictionaryEntry>
+              <DictionaryEntry>
+                <DictionaryKey>Action</DictionaryKey>
+                <DictionaryValue>
+                  <EventFilterActionLabel action={action} />
+                </DictionaryValue>
+              </DictionaryEntry>
+            </Dictionary>
+          </Grid>
         </Grid>
-      </Grid>
-    </CardContent>
-    <Divider />
-    <CardContent>
-      <Grid container spacing={0}>
-        <Grid item xs={12}>
-          <Dictionary>
-            <DictionaryEntry fullWidth={!!eventFilter.expressions}>
-              <DictionaryKey>Expressions</DictionaryKey>
-              <DictionaryValue>
-                {eventFilter.expressions &&
-                eventFilter.expressions.length > 0 ? (
-                  <CodeBlock>
-                    <CodeHighlight
-                      language="javascript"
-                      code={eventFilter.expressions.join("\n")}
-                    />
-                  </CodeBlock>
-                ) : (
-                  "None"
-                )}
-              </DictionaryValue>
-            </DictionaryEntry>
-          </Dictionary>
+      </CardContent>
+      <Divider />
+      <CardContent>
+        <Grid container spacing={0}>
+          <Grid item xs={12}>
+            <Dictionary>
+              <DictionaryEntry fullWidth={!!expressions}>
+                <DictionaryKey>Expressions</DictionaryKey>
+                <DictionaryValue>
+                  {expressions && expressions.length > 0 ? (
+                    <CodeBlock>
+                      <CodeHighlight
+                        language="javascript"
+                        code={expressions.join("\n")}
+                      />
+                    </CodeBlock>
+                  ) : (
+                    "None"
+                  )}
+                </DictionaryValue>
+              </DictionaryEntry>
+            </Dictionary>
+          </Grid>
         </Grid>
-      </Grid>
-    </CardContent>
-    <Divider />
-    <CardContent>
-      <Grid container spacing={0}>
-        <Grid item xs={12}>
-          <Dictionary>
-            <DictionaryEntry fullWidth={!!eventFilter.runtimeAssets}>
-              <DictionaryKey>Runtime Assets</DictionaryKey>
-              <DictionaryValue>
-                {eventFilter.runtimeAssets &&
-                eventFilter.runtimeAssets.length > 0 ? (
-                  <CodeBlock>
-                    <CodeHighlight
-                      language="properties"
-                      code={eventFilter.runtimeAssets.join("\n")}
-                    />
-                  </CodeBlock>
-                ) : (
-                  "None"
-                )}
-              </DictionaryValue>
-            </DictionaryEntry>
-          </Dictionary>
-        </Grid>
-      </Grid>
-    </CardContent>
-    <Divider />
-    <LabelsAnnotationsCell resource={eventFilter} />
-  </Card>
-);
+      </CardContent>
+      <Divider />
+      <RuntimeAssetsCell runtimeAssets={runtimeAssets} />
+      <Divider />
+      <LabelsAnnotationsCell resource={eventFilter} />
+    </Card>
+  );
+};
 
 EventFilterDetailsConfiguration.fragments = {
   eventFilter: gql`
@@ -118,11 +100,15 @@ EventFilterDetailsConfiguration.fragments = {
       name
       action
       expressions
+      runtimeAssets {
+        ...RuntimeAssetsCell_assets
+      }
       metadata {
         ...LabelsAnnotationsCell_objectmeta
       }
     }
     ${LabelsAnnotationsCell.fragments.objectmeta}
+    ${RuntimeAssetsCell.fragments.assets}
   `,
 };
 

--- a/src/lib/component/partial/RuntimeAssetsCell/RuntimeAssetsCell.tsx
+++ b/src/lib/component/partial/RuntimeAssetsCell/RuntimeAssetsCell.tsx
@@ -1,0 +1,59 @@
+import React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import { Grid, CardContent } from "/vendor/@material-ui/core";
+
+import {
+  Dictionary,
+  DictionaryKey,
+  DictionaryValue,
+  DictionaryEntry,
+  CodeBlock,
+  CodeHighlight,
+} from "/lib/component/base";
+
+export interface RuntimeAsset {
+  name: string;
+}
+
+interface Props {
+  runtimeAssets: RuntimeAsset[];
+}
+
+const RuntimeAssetsCell = ({ runtimeAssets }: Props) => {
+  return (
+    <CardContent>
+      <Grid container spacing={0}>
+        <Grid item xs={12}>
+          <Dictionary>
+            <DictionaryEntry fullWidth={!!runtimeAssets}>
+              <DictionaryKey>Runtime Assets</DictionaryKey>
+              <DictionaryValue>
+                {runtimeAssets && runtimeAssets.length > 0 ? (
+                  <CodeBlock>
+                    <CodeHighlight
+                      language="properties"
+                      code={runtimeAssets.map(({ name }) => name).join("\n")}
+                    />
+                  </CodeBlock>
+                ) : (
+                  "None"
+                )}
+              </DictionaryValue>
+            </DictionaryEntry>
+          </Dictionary>
+        </Grid>
+      </Grid>
+    </CardContent>
+  );
+};
+
+RuntimeAssetsCell.fragments = {
+  assets: gql`
+    fragment RuntimeAssetsCell_assets on Asset {
+      name
+    }
+  `,
+};
+
+export default RuntimeAssetsCell;

--- a/src/lib/component/partial/RuntimeAssetsCell/index.tsx
+++ b/src/lib/component/partial/RuntimeAssetsCell/index.tsx
@@ -1,0 +1,2 @@
+export { default } from "./RuntimeAssetsCell";
+export * from "./RuntimeAssetsCell";

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -56,6 +56,7 @@ export { default as QuickNav } from "./QuickNav";
 export { default as RelatedEntitiesCard } from "./RelatedEntitiesCard";
 export { default as ResetAdornment } from "./ResetAdornment";
 export { default as ResourceDetails } from "./ResourceDetails";
+export { default as RuntimeAssetsCell } from "./RuntimeAssetsCell";
 export { default as SigninDialog } from "./SigninDialog";
 export { default as SilenceEntryDialog } from "./SilenceEntryDialog";
 export { SilenceEntryForm, SilenceEntryFormFields } from "./SilenceEntryForm";


### PR DESCRIPTION
## What is this change?
This change creates the `RuntimeAssetsCell` component and implements it in the `EventFilterDetailsConfiguration` component to render a list runtime assets. Previously, we had a UI element for runtime assets, but the `runtimeAssets` key wasn't added to the EventFilters query, so nothing would render.

<img width="1021" alt="Screen Shot 2019-06-28 at 4 09 29 PM" src="https://user-images.githubusercontent.com/3856248/60375660-292b0800-99bf-11e9-8f27-03041755a992.png">

## How did you verify this change?
Manually.