### PR TITLE
[Bug] Disable re-run action for proxy entity checks

### DIFF
--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsReRunAction.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsReRunAction.js
@@ -17,7 +17,10 @@ const EventDetailsReRunAction = ({ children, event, client }) => {
 
   const createExecuteCheckStatusToast = useExecuteCheckStatusToast();
 
-  return children(() => {
+  const disableRunCheck =
+    event.check.name === "keepalive" || subscriptions.length <= 0;
+
+  const runCheck = () => {
     const promise = executeCheck(client, {
       id: event.check.nodeId,
       subscriptions,
@@ -28,7 +31,9 @@ const EventDetailsReRunAction = ({ children, event, client }) => {
       entityName: event.entity.name,
       namespace: event.namespace,
     });
-  });
+  };
+
+  return children({ runCheck, canRunCheck: !disableRunCheck });
 };
 
 EventDetailsReRunAction.fragments = {
@@ -37,6 +42,7 @@ EventDetailsReRunAction.fragments = {
       check {
         nodeId
         proxyEntityName
+        name
       }
       entity {
         name

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsToolbar.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsToolbar.js
@@ -70,17 +70,16 @@ class EventDetailsToolbar extends React.Component {
                   </ResolveAction>
                 </ToolbarMenu.Item>,
                 <ToolbarMenu.Item key="re-run" visible="if-room">
-                  {event.check.name !== "keepalive" && (
-                    <ReRunAction event={event}>
-                      {run => (
-                        <QueueExecutionMenuItem
-                          title="Re-run Check"
-                          titleCondensed="Re-run"
-                          onClick={run}
-                        />
-                      )}
-                    </ReRunAction>
-                  )}
+                  <ReRunAction event={event}>
+                    {({ runCheck, canRunCheck }) => (
+                      <QueueExecutionMenuItem
+                        title="Re-run Check"
+                        titleCondensed="Re-run"
+                        disabled={!canRunCheck}
+                        onClick={runCheck}
+                      />
+                    )}
+                  </ReRunAction>
                 </ToolbarMenu.Item>,
                 <ToolbarMenu.Item
                   key="silence"


### PR DESCRIPTION
## What is this change?

This change disables the "re-run" button for Proxy Entity Checks and for "keepalive" checks.

Previously, the Web UI allowed users to attempt to re-run a check against a proxy entity, but it wouldn't do anything because our application sends an empty array of subscriptions to the `executeCheck` mutation when the entity is a proxy entity.

The reason we don't preform check re-runs against proxy entities because to do so we would need to re-run the check against all its subscriptions. We believe that, as a user, clicking re-run on a check and having the check run against all subscriptions is not expected behaviour, and could lead to unwanted results.

In the future, we may implement a dialogue that would allow the user to select which subscriptions a check is run against, so that users have more control over what happens when a check is re-run. However, for the time being, we are going to remove the “re-run” button from the Check Results screen for proxy entity checks.

![2019-07-02 15 21 00](https://user-images.githubusercontent.com/3856248/60550585-53413a80-9cdd-11e9-9125-c21a27efd733.gif)

## Why is this change necessary?
Closes #37 and addresses a [community question](https://sensucommunity.slack.com/archives/C68LV5M9U/p1561729586306600) 

## How did you verify this change?
Manually.
