### PR TITLE
Namespaces with hyphen are inline in drawer

### DIFF
--- a/src/lib/component/partial/Drawer.js
+++ b/src/lib/component/partial/Drawer.js
@@ -40,9 +40,6 @@ const styles = theme => ({
     paddingTop: "env(safe-area-inset-top)",
     backgroundColor: theme.palette.primary.dark,
   },
-  header: {
-    height: 172,
-  },
   row: {
     display: "flex",
     flexWrap: "wrap",

--- a/src/lib/component/partial/Drawer.js
+++ b/src/lib/component/partial/Drawer.js
@@ -50,9 +50,8 @@ const styles = theme => ({
     margin: "16px 16px 0 0",
   },
   namespaceSelector: {
-    margin: "8px 0 -8px 0",
+    margin: "8px 0 0 0",
     width: "100%",
-    height: 56,
   },
   namespaceIcon: {
     margin: "24px 0 0 16px",

--- a/src/lib/component/partial/NamespaceLabel/NamespaceLabelBase.js
+++ b/src/lib/component/partial/NamespaceLabel/NamespaceLabelBase.js
@@ -34,18 +34,11 @@ class NamespaceLabelBase extends React.Component {
 
   render() {
     const { classes, name, icon, colour } = this.props;
-    const nsComponents = name.split("-");
 
     return (
       <div className={classes.container}>
         <Typography className={classes.label} variant="subtitle1">
-          {nsComponents.length > 1 && (
-            <React.Fragment>
-              <span className={classes.lighter}>{nsComponents.shift()}</span>
-              {" - "}
-            </React.Fragment>
-          )}
-          <span className={classes.heavier}>{nsComponents.join("-")}</span>
+          {name}
         </Typography>
 
         <Icon icon={icon} colour={colour} />

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelectorBuilder.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelectorBuilder.js
@@ -11,13 +11,6 @@ const styles = theme => ({
     opacity: 0.9,
     display: "block",
   },
-  heavier: {
-    fontWeight: 400,
-  },
-  lighter: {
-    fontWeight: 300,
-    opacity: 0.71,
-  },
   nameLabel: {
     fontSize: "1.25rem",
   },
@@ -28,6 +21,7 @@ const styles = theme => ({
   },
   arrow: {
     color: theme.palette.primary.contrastText,
+    paddingTop: "4px",
   },
 });
 
@@ -44,8 +38,6 @@ class NamespaceSelectorBuilder extends React.Component {
   render() {
     const { classes, namespace } = this.props;
 
-    const nsComponents = namespace.name.split("-");
-
     return (
       <div className={classes.selectorContainer}>
         <div className={classes.nameContainer}>
@@ -53,13 +45,7 @@ class NamespaceSelectorBuilder extends React.Component {
             className={classNames(classes.label, classes.nameLabel)}
             variant="subtitle1"
           >
-            {nsComponents.length > 1 && (
-              <React.Fragment>
-                <span className={classes.lighter}>{nsComponents.shift()}</span>
-                {" - "}
-              </React.Fragment>
-            )}
-            <span className={classes.heavier}>{nsComponents.join("-")}</span>
+            {namespace.name}
           </Typography>
           <span className={classes.arrow}>
             <ArrowDropDownIcon />

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelectorBuilder.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelectorBuilder.js
@@ -11,9 +11,12 @@ const styles = theme => ({
     opacity: 0.9,
     display: "block",
   },
-  prefixLabel: {
-    fontWeight: "lighter",
-    fontSize: "0.75rem",
+  heavier: {
+    fontWeight: 400,
+  },
+  lighter: {
+    fontWeight: 300,
+    opacity: 0.71,
   },
   nameLabel: {
     fontSize: "1.25rem",
@@ -41,22 +44,22 @@ class NamespaceSelectorBuilder extends React.Component {
   render() {
     const { classes, namespace } = this.props;
 
-    let [prefix, ...name] = namespace ? namespace.name.split("-") : [];
-    if (name.length === 0) {
-      name = prefix;
-      prefix = null;
-    } else {
-      name = name.join("-");
-    }
+    const nsComponents = namespace.name.split("-");
 
     return (
       <div className={classes.selectorContainer}>
-        <Typography className={classNames(classes.label, classes.prefixLabel)}>
-          {prefix || " "}
-        </Typography>
         <div className={classes.nameContainer}>
-          <Typography className={classNames(classes.label, classes.nameLabel)}>
-            {name}
+          <Typography
+            className={classNames(classes.label, classes.nameLabel)}
+            variant="subtitle1"
+          >
+            {nsComponents.length > 1 && (
+              <React.Fragment>
+                <span className={classes.lighter}>{nsComponents.shift()}</span>
+                {" - "}
+              </React.Fragment>
+            )}
+            <span className={classes.heavier}>{nsComponents.join("-")}</span>
           </Typography>
           <span className={classes.arrow}>
             <ArrowDropDownIcon />

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelectorBuilder.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelectorBuilder.js
@@ -17,11 +17,12 @@ const styles = theme => ({
   nameContainer: {
     margin: "-6px 0 0",
     display: "flex",
+    height: "32px",
     justifyContent: "space-between",
   },
   arrow: {
     color: theme.palette.primary.contrastText,
-    paddingTop: "4px",
+    paddingTop: "6px",
   },
 });
 


### PR DESCRIPTION
## What is this change?
Closes #162 
Changes the namespace selector in the drawer to show namespace in one line, just like the topbar.

<img width="284" alt="Screen Shot 2019-07-10 at 9 47 37 PM" src="https://user-images.githubusercontent.com/1707663/61022849-5af78380-a35c-11e9-901c-a403b9b4c120.png">

## Why is this change necessary?
It was requested.