### PR TITLE
Fix imports to appease Cypress Testing Framework

### DIFF
--- a/src/lib/component/partial/ToolbarSelect/Button.js
+++ b/src/lib/component/partial/ToolbarSelect/Button.js
@@ -1,7 +1,7 @@
 import React from "/vendor/react";
 import PropTypes from "prop-types";
 
-import { button as BaseButton } from "/vendor/@material-ui/core";
+import { Button as BaseButton } from "/vendor/@material-ui/core";
 
 class Button extends React.PureComponent {
   static displayName = "ToolbarSelect.Button";

--- a/src/vendor/react-router-dom.tsx
+++ b/src/vendor/react-router-dom.tsx
@@ -1,2 +1,1 @@
-export { default } from "react-router-dom";
 export * from "react-router-dom";


### PR DESCRIPTION
## What is this change?
This change fixes a few erroneous imports in the repo that cause our Cypress testing framework to error on when developing in our https://github.com/sensu/sensu-enterprise-go repo.

## Why is this change necessary?
This change supports exploration we are doing into the Cypress testing framework for end-to-end test

## Does your change need a Changelog entry?
No.

## How did you verify this change?
Manually, by building and running the application without issue.