### PR TITLE
Handle rejected result; fix refresh token crash

### DIFF
--- a/src/lib/component/util/AuthInvalidRoute.js
+++ b/src/lib/component/util/AuthInvalidRoute.js
@@ -1,27 +1,32 @@
 import React from "/vendor/react";
-import PropTypes from "prop-types";
-import { graphql } from "/vendor/react-apollo";
 import gql from "/vendor/graphql-tag";
 
-import ConditionalRoute from "/lib/component/util/ConditionalRoute";
+import { FailedError } from "/lib/error/FetchError";
 
-class AuthInvalidRoute extends React.PureComponent {
-  static propTypes = {
-    ...ConditionalRoute.propTypes,
-    data: PropTypes.object.isRequired,
-  };
+import ConditionalRoute from "./ConditionalRoute";
+import useQuery from "./useQuery";
 
-  render() {
-    const { data, ...props } = this.props;
-
-    return <ConditionalRoute {...props} active={data.auth.invalid} />;
-  }
-}
-
-export default graphql(gql`
+const AuthInvalidRouteQuery = gql`
   query AuthInvalidRouteQuery {
     auth @client {
       invalid
     }
   }
-`)(AuthInvalidRoute);
+`;
+
+const AuthInvalidRoute = props => {
+  const { data = {} } = useQuery({
+    query: AuthInvalidRouteQuery,
+    onError: err => {
+      if (err.networkError instanceof FailedError) {
+        return;
+      }
+
+      throw err;
+    },
+  });
+
+  return <ConditionalRoute {...props} active={data.auth.invalid} />;
+};
+
+export default AuthInvalidRoute;

--- a/src/lib/component/util/useQuery.tsx
+++ b/src/lib/component/util/useQuery.tsx
@@ -142,7 +142,10 @@ function useQuery<TData = any, TVariables = OperationVariables>(
       modifiableOptionsHaveChanged(configRef.current, prevConfigRef.current)
     ) {
       // Certain options can be modified without discarding the observable.
-      observableRef.current.setOptions(configRef.current);
+      observableRef.current.setOptions(configRef.current)
+        // Any rejection here will also be passed to the query observer below.
+        // There is no benefit to handling the error here as well.
+        .catch(() => null);
     }
   }
 


### PR DESCRIPTION
If rejected discards the error from the promise returned by QueryObservable's `setOptions` method. Said error is already handled by the query subscription and there is no need to handle it twice.

Closes #169