### PR TITLE
Use namespaces endpoint

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -14,7 +14,7 @@ import "./util/exceptionHandler";
 import config from "../config/app.webpack.config";
 
 const root = fs.realpathSync(process.cwd());
-const proxyPaths = ["/auth", "/graphql"];
+const proxyPaths = ["/auth", "/graphql", "/api"];
 const port = parseInt(process.env.PORT, 10) || 3001;
 
 const compiler = webpack(config);

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -19,6 +19,7 @@ import {
   LastNamespaceRedirect,
   NamespaceRoute,
   NavigationProvider,
+  SyncNamespaces,
 } from "/lib/component/util";
 
 import {
@@ -76,106 +77,108 @@ const renderApp = () => {
             <NamespaceRoute
               path="/:namespace"
               render={props => (
-                <NavigationProvider
-                  links={[
-                    {
-                      to: `${props.match.url}/events`,
-                      icon: EventIcon,
-                      caption: "Events",
-                    },
-                    {
-                      to: `${props.match.url}/entities`,
-                      icon: EntityIcon,
-                      caption: "Entities",
-                    },
-                    {
-                      to: `${props.match.url}/checks`,
-                      icon: CheckIcon,
-                      caption: "Checks",
-                    },
-                    {
-                      to: `${props.match.url}/filters`,
-                      icon: EventFilterIcon,
-                      caption: "Filters",
-                    },
-                    {
-                      to: `${props.match.url}/handlers`,
-                      icon: HandlerIcon,
-                      caption: "Handlers",
-                    },
-                    {
-                      to: `${props.match.url}/mutators`,
-                      icon: MutatorIcon,
-                      caption: "Mutators",
-                    },
-                    {
-                      to: `${props.match.url}/silences`,
-                      icon: SilenceIcon,
-                      caption: "Silences",
-                    },
-                  ]}
-                >
-                  <Switch>
-                    <Redirect
-                      exact
-                      from={props.match.path}
-                      to={`${props.match.path}/events`}
-                    />
-                    <Route
-                      path={`${props.match.path}/checks/:check`}
-                      component={CheckDetailsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/events/:entity/:check`}
-                      component={EventDetailsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/filters/:filter`}
-                      component={EventFilterDetailsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/entities/:entity`}
-                      component={EntityDetailsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/handlers/:handler`}
-                      component={HandlerDetailsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/mutators/:mutator`}
-                      component={MutatorDetailsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/checks`}
-                      component={ChecksView}
-                    />
-                    <Route
-                      path={`${props.match.path}/entities`}
-                      component={EntitiesView}
-                    />
-                    <Route
-                      path={`${props.match.path}/events`}
-                      component={EventsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/filters`}
-                      component={EventFiltersView}
-                    />
-                    <Route
-                      path={`${props.match.path}/handlers`}
-                      component={HandlersView}
-                    />
-                    <Route
-                      path={`${props.match.path}/mutators`}
-                      component={MutatorsView}
-                    />
-                    <Route
-                      path={`${props.match.path}/silences`}
-                      component={SilencesView}
-                    />
-                    <Route render={() => "not found in namespace"} />
-                  </Switch>
-                </NavigationProvider>
+                <SyncNamespaces>
+                  <NavigationProvider
+                    links={[
+                      {
+                        to: `${props.match.url}/events`,
+                        icon: EventIcon,
+                        caption: "Events",
+                      },
+                      {
+                        to: `${props.match.url}/entities`,
+                        icon: EntityIcon,
+                        caption: "Entities",
+                      },
+                      {
+                        to: `${props.match.url}/checks`,
+                        icon: CheckIcon,
+                        caption: "Checks",
+                      },
+                      {
+                        to: `${props.match.url}/filters`,
+                        icon: EventFilterIcon,
+                        caption: "Filters",
+                      },
+                      {
+                        to: `${props.match.url}/handlers`,
+                        icon: HandlerIcon,
+                        caption: "Handlers",
+                      },
+                      {
+                        to: `${props.match.url}/mutators`,
+                        icon: MutatorIcon,
+                        caption: "Mutators",
+                      },
+                      {
+                        to: `${props.match.url}/silences`,
+                        icon: SilenceIcon,
+                        caption: "Silences",
+                      },
+                    ]}
+                  >
+                    <Switch>
+                      <Redirect
+                        exact
+                        from={props.match.path}
+                        to={`${props.match.path}/events`}
+                      />
+                      <Route
+                        path={`${props.match.path}/checks/:check`}
+                        component={CheckDetailsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/events/:entity/:check`}
+                        component={EventDetailsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/filters/:filter`}
+                        component={EventFilterDetailsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/entities/:entity`}
+                        component={EntityDetailsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/handlers/:handler`}
+                        component={HandlerDetailsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/mutators/:mutator`}
+                        component={MutatorDetailsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/checks`}
+                        component={ChecksView}
+                      />
+                      <Route
+                        path={`${props.match.path}/entities`}
+                        component={EntitiesView}
+                      />
+                      <Route
+                        path={`${props.match.path}/events`}
+                        component={EventsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/filters`}
+                        component={EventFiltersView}
+                      />
+                      <Route
+                        path={`${props.match.path}/handlers`}
+                        component={HandlersView}
+                      />
+                      <Route
+                        path={`${props.match.path}/mutators`}
+                        component={MutatorsView}
+                      />
+                      <Route
+                        path={`${props.match.path}/silences`}
+                        component={SilencesView}
+                      />
+                      <Route render={() => "not found in namespace"} />
+                    </Switch>
+                  </NavigationProvider>
+                </SyncNamespaces>
               )}
               fallbackComponent={NamespaceNotFoundView}
             />

--- a/src/lib/component/partial/AppBar.js
+++ b/src/lib/component/partial/AppBar.js
@@ -30,13 +30,6 @@ class AppBar extends React.Component {
   static defaultProps = { namespace: null, viewer: null };
 
   static fragments = {
-    viewer: gql`
-      fragment AppBar_viewer on Viewer {
-        ...Drawer_viewer
-      }
-      ${Drawer.fragments.viewer}
-    `,
-
     namespace: gql`
       fragment AppBar_namespace on Namespace {
         ...NamespaceLabel_namespace
@@ -81,7 +74,7 @@ class AppBar extends React.Component {
   };
 
   render() {
-    const { namespace, viewer, loading, classes } = this.props;
+    const { namespace, loading, classes } = this.props;
 
     return (
       <React.Fragment>
@@ -110,7 +103,6 @@ class AppBar extends React.Component {
         </MUIAppBar>
         <Drawer
           loading={loading}
-          viewer={viewer}
           open={this.state.drawerOpen}
           onToggle={this.handleToggleDrawer}
           namespace={namespace}

--- a/src/lib/component/partial/AppLayout.js
+++ b/src/lib/component/partial/AppLayout.js
@@ -24,16 +24,11 @@ class AppLayout extends React.PureComponent {
 
   static query = gql`
     query AppLayoutQuery($namespace: String!) {
-      viewer {
-        ...AppBar_viewer
-      }
-
       namespace(name: $namespace) {
         ...AppBar_namespace
       }
     }
 
-    ${AppBar.fragments.viewer}
     ${AppBar.fragments.namespace}
   `;
 
@@ -60,7 +55,6 @@ class AppLayout extends React.PureComponent {
                 <AppBar
                   loading={loading || aborted}
                   namespace={data.namespace}
-                  viewer={data.viewer}
                 />
               }
               quickNav={

--- a/src/lib/component/partial/Drawer.js
+++ b/src/lib/component/partial/Drawer.js
@@ -70,7 +70,6 @@ class Drawer extends React.Component {
   static propTypes = {
     client: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired,
-    viewer: PropTypes.object,
     namespace: PropTypes.object,
     onToggle: PropTypes.func.isRequired,
     open: PropTypes.bool.isRequired,
@@ -80,22 +79,11 @@ class Drawer extends React.Component {
   static defaultProps = { loading: false, viewer: null, namespace: null };
 
   static fragments = {
-    viewer: gql`
-      fragment Drawer_viewer on Viewer {
-        ...NamespaceSelector_viewer
-      }
-
-      ${NamespaceSelector.fragments.viewer}
-      ${NamespaceSelector.fragments.namespace}
-    `,
-
     namespace: gql`
       fragment Drawer_namespace on Namespace {
         ...NamespaceIcon_namespace
-        ...NamespaceSelector_namespace
       }
 
-      ${NamespaceSelector.fragments.namespace}
       ${NamespaceIcon.fragments.namespace}
     `,
   };
@@ -105,15 +93,7 @@ class Drawer extends React.Component {
   };
 
   render() {
-    const {
-      client,
-      loading,
-      viewer,
-      namespace,
-      open,
-      onToggle,
-      classes,
-    } = this.props;
+    const { client, loading, namespace, open, onToggle, classes } = this.props;
     const { preferencesOpen } = this.state;
 
     return (
@@ -149,7 +129,6 @@ class Drawer extends React.Component {
                 </div>
                 <div className={classes.row}>
                   <NamespaceSelector
-                    viewer={viewer}
                     namespace={namespace}
                     className={classes.namespaceSelector}
                     onChange={onToggle}

--- a/src/lib/component/partial/NamespaceIcon/Connected.js
+++ b/src/lib/component/partial/NamespaceIcon/Connected.js
@@ -23,7 +23,7 @@ class NamespaceIcon extends React.Component {
 
   render() {
     const { namespace: ns, ...props } = this.props;
-    return <Icon icon={ns.icon} colour={ns.colour} {...props} />;
+    return <Icon icon={ns.icon || "BRIEFCASE"} colour={ns.colour} {...props} />;
   }
 }
 

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelector.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelector.js
@@ -1,10 +1,9 @@
 import React from "/vendor/react";
 import PropTypes from "prop-types";
 import { Route } from "/vendor/react-router-dom";
-import gql from "/vendor/graphql-tag";
 import { withStyles, ButtonBase as Button } from "/vendor/@material-ui/core";
 
-import { NamespacesContext } from "/lib/util/NamespacesContext";
+import { WithNamespaces } from "/lib/component/util";
 import NamespaceSelectorBuilder from "./NamespaceSelectorBuilder";
 import NamespaceSelectorMenu from "./NamespaceSelectorMenu";
 
@@ -67,7 +66,7 @@ class NamespaceSelector extends React.Component {
             >
               <NamespaceSelectorBuilder namespace={namespace} />
             </Button>
-            <NamespacesContext.Consumer>
+            <WithNamespaces>
               {namespaces => (
                 <NamespaceSelectorMenu
                   anchorEl={anchorEl}
@@ -82,7 +81,7 @@ class NamespaceSelector extends React.Component {
                   }}
                 />
               )}
-            </NamespacesContext.Consumer>
+            </WithNamespaces>
           </div>
         )}
       />

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelector.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelector.js
@@ -4,6 +4,7 @@ import { Route } from "/vendor/react-router-dom";
 import gql from "/vendor/graphql-tag";
 import { withStyles, ButtonBase as Button } from "/vendor/@material-ui/core";
 
+import { NamespacesContext } from "/lib/util/NamespacesContext";
 import NamespaceSelectorBuilder from "./NamespaceSelectorBuilder";
 import NamespaceSelectorMenu from "./NamespaceSelectorMenu";
 
@@ -29,22 +30,6 @@ class NamespaceSelector extends React.Component {
     viewer: null,
     namespace: null,
     loading: false,
-  };
-
-  static fragments = {
-    viewer: gql`
-      fragment NamespaceSelector_viewer on Viewer {
-        ...NamespaceSelectorMenu_viewer
-      }
-
-      ${NamespaceSelectorMenu.fragments.viewer}
-    `,
-
-    namespace: gql`
-      fragment NamespaceSelector_namespace on Namespace {
-        name
-      }
-    `,
   };
 
   state = {
@@ -82,18 +67,22 @@ class NamespaceSelector extends React.Component {
             >
               <NamespaceSelectorBuilder namespace={namespace} />
             </Button>
-            <NamespaceSelectorMenu
-              anchorEl={anchorEl}
-              id="drawer-selector-menu"
-              viewer={viewer}
-              org={params.organization}
-              open={Boolean(anchorEl)}
-              onClose={this.onClose}
-              onClick={ev => {
-                this.onClose();
-                onChange(ev);
-              }}
-            />
+            <NamespacesContext.Consumer>
+              {namespaces => (
+                <NamespaceSelectorMenu
+                  anchorEl={anchorEl}
+                  id="drawer-selector-menu"
+                  namespaces={namespaces}
+                  org={params.organization}
+                  open={Boolean(anchorEl)}
+                  onClose={this.onClose}
+                  onClick={ev => {
+                    this.onClose();
+                    onChange(ev);
+                  }}
+                />
+              )}
+            </NamespacesContext.Consumer>
           </div>
         )}
       />

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelectorMenu.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelectorMenu.js
@@ -27,7 +27,7 @@ class NamespaceSelectorMenu extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     onClick: PropTypes.func.isRequired,
-    namespaces: PropTypes.object,
+    namespaces: PropTypes.array,
   };
 
   static defaultProps = {

--- a/src/lib/component/partial/NamespaceSelector/NamespaceSelectorMenu.js
+++ b/src/lib/component/partial/NamespaceSelector/NamespaceSelectorMenu.js
@@ -1,6 +1,5 @@
 import React from "/vendor/react";
 import PropTypes from "prop-types";
-import gql from "/vendor/graphql-tag";
 import { Link } from "/vendor/react-router-dom";
 
 import {
@@ -28,34 +27,17 @@ class NamespaceSelectorMenu extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     onClick: PropTypes.func.isRequired,
-    viewer: PropTypes.object,
+    namespaces: PropTypes.object,
   };
 
   static defaultProps = {
     viewer: null,
   };
 
-  static fragments = {
-    viewer: gql`
-      fragment NamespaceSelectorMenu_viewer on Viewer {
-        namespaces {
-          name
-          ...NamespaceIcon_namespace
-        }
-      }
-
-      ${NamespaceIcon.fragments.namespace}
-    `,
-  };
-
   render() {
-    const { viewer, classes, onClick, ...props } = this.props;
+    const { namespaces, classes, onClick, ...props } = this.props;
 
-    if (!viewer) {
-      return null;
-    }
-
-    const groups = viewer.namespaces.reduce((acc, ns) => {
+    const groups = namespaces.reduce((acc, ns) => {
       const [key] = ns.name.split("-", 1);
 
       acc[key] = acc[key] || [];
@@ -67,11 +49,11 @@ class NamespaceSelectorMenu extends React.Component {
     return (
       <Menu {...props}>
         {Object.keys(groups).map((key, i) => {
-          const namesapces = groups[key];
+          const namespaces = groups[key];
 
           return (
             <React.Fragment key={`prefix-${key}`}>
-              {namesapces.map(namespace => (
+              {namespaces.map(namespace => (
                 <Link
                   key={namespace.name}
                   to={`/${namespace.name}`}

--- a/src/lib/component/util/NamespacesProvider/NamespacesProvider.js
+++ b/src/lib/component/util/NamespacesProvider/NamespacesProvider.js
@@ -1,0 +1,15 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+
+import Context from "./context";
+
+const NamespacesProvider = ({ namespaces, children }) => {
+  return <Context.Provider value={namespaces}>{children}</Context.Provider>;
+};
+
+NamespacesProvider.propTypes = {
+  children: PropTypes.node,
+  namespaces: PropTypes.array,
+};
+
+export default NamespacesProvider;

--- a/src/lib/component/util/NamespacesProvider/WithNamespaces.js
+++ b/src/lib/component/util/NamespacesProvider/WithNamespaces.js
@@ -1,0 +1,7 @@
+import React from "/vendor/react";
+
+import Context from "./context";
+
+const WithNamespaces = props => <Context.Consumer {...props} />;
+
+export default WithNamespaces;

--- a/src/lib/component/util/NamespacesProvider/context.js
+++ b/src/lib/component/util/NamespacesProvider/context.js
@@ -1,0 +1,3 @@
+import React from "/vendor/react";
+
+export default React.createContext([]);

--- a/src/lib/component/util/NamespacesProvider/index.js
+++ b/src/lib/component/util/NamespacesProvider/index.js
@@ -1,0 +1,2 @@
+export { default } from "./NamespacesProvider";
+export { default as WithNamespaces } from "./WithNamespaces";

--- a/src/lib/component/util/SyncNamespaces.js
+++ b/src/lib/component/util/SyncNamespaces.js
@@ -1,0 +1,49 @@
+import React, { useState, useMemo } from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import { FailedError } from "/lib/error/FetchError";
+import useQuery from "./useQuery";
+// TODO rename NamespacesContext to NamespacesProvider
+// TODO useNamespaces (instead of withNavagation, as a hook)
+import { NamespacesContext } from "/lib/util/NamespacesContext";
+import { fetchNamespaces } from "/lib/util/namespaceAPI";
+
+const query = gql`
+  query AuthQuery {
+    auth @client {
+      accessToken
+    }
+  }
+`;
+
+const SyncNamespaces = ({ children }) => {
+  const namespaceQuery = useQuery({
+    query: query,
+    onError: err => {
+      if (err.networkError instanceof FailedError) {
+        return;
+      }
+
+      throw err;
+    },
+  });
+
+  // TODO: deal with error/empty case for query
+  // TODO: deal with weird results from fetchNamespaces too
+  const [namespaces, setNamespaces] = useState([]);
+  useMemo(() => {
+    fetchNamespaces(namespaceQuery.data.auth)
+      .then(data => {
+        setNamespaces(data);
+      })
+      .catch(console.error);
+    // eslint-disable-next-line
+  }, []);
+  return (
+    <NamespacesContext.Provider value={namespaces}>
+      {children}
+    </NamespacesContext.Provider>
+  );
+};
+
+export default SyncNamespaces;

--- a/src/lib/component/util/index.tsx
+++ b/src/lib/component/util/index.tsx
@@ -20,6 +20,7 @@ export {
 export { default as Query } from "./Query";
 export { default as RenderCounter } from "./RenderCounter";
 export { default as SigninRedirect } from "./SigninRedirect";
+export { default as SyncNamespaces } from "./SyncNamespaces";
 export { default as Timer } from "./Timer";
 export { default as UnauthenticatedRoute } from "./UnauthenticatedRoute";
 export { default as UnmountObserver } from "./UnmountObserver";

--- a/src/lib/component/util/index.tsx
+++ b/src/lib/component/util/index.tsx
@@ -12,6 +12,10 @@ export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as LastNamespaceRedirect } from "./LastNamespaceRedirect";
 export { default as LastNamespaceUpdater } from "./LastNamespaceUpdater";
 export { default as NamespaceLink } from "./NamespaceLink";
+export {
+  default as NamespacesProvider,
+  WithNamespaces,
+} from "./NamespacesProvider";
 export { default as NamespaceRoute } from "./NamespaceRoute";
 export {
   default as NavigationProvider,

--- a/src/lib/util/NamespacesContext.js
+++ b/src/lib/util/NamespacesContext.js
@@ -1,0 +1,3 @@
+import React from "/vendor/react";
+
+export const NamespacesContext = React.createContext([]);

--- a/src/lib/util/NamespacesContext.js
+++ b/src/lib/util/NamespacesContext.js
@@ -1,3 +1,0 @@
-import React from "/vendor/react";
-
-export const NamespacesContext = React.createContext([]);

--- a/src/lib/util/namespaceAPI.js
+++ b/src/lib/util/namespaceAPI.js
@@ -1,25 +1,8 @@
-import gql from "/vendor/graphql-tag";
-
-import {
-  createTokens,
-  invalidateTokens,
-  refreshTokens,
-} from "/lib/util/authAPI";
 import { when } from "/lib/util/promise";
 import { UnauthorizedError } from "/lib/error/FetchError";
 
-const query = gql`
-  query AuthQuery {
-    auth @client {
-      accessToken
-      refreshToken
-      expiresAt
-    }
-  }
-`;
-
-export const fetchNamespaces = ({ accessToken, refreshToken }) => {
-  const path = "/user-namespaces";
+export const fetchNamespaces = ({ accessToken }) => {
+  const path = "/api/core/v2/namespaces";
   const config = {
     method: "GET",
     headers: {
@@ -27,15 +10,8 @@ export const fetchNamespaces = ({ accessToken, refreshToken }) => {
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({
-      refresh_token: refreshToken,
-    }),
   };
   return fetch(path, config)
-    .catch(when(UnauthorizedError, () => {}))
-    .then(() => ({
-      accessToken: null,
-      refreshToken: null,
-      expiresAt: null,
-    }));
+    .then(response => response.json())
+    .catch(when(UnauthorizedError, () => {}));
 };

--- a/src/lib/util/namespaceAPI.js
+++ b/src/lib/util/namespaceAPI.js
@@ -1,0 +1,41 @@
+import gql from "/vendor/graphql-tag";
+
+import {
+  createTokens,
+  invalidateTokens,
+  refreshTokens,
+} from "/lib/util/authAPI";
+import { when } from "/lib/util/promise";
+import { UnauthorizedError } from "/lib/error/FetchError";
+
+const query = gql`
+  query AuthQuery {
+    auth @client {
+      accessToken
+      refreshToken
+      expiresAt
+    }
+  }
+`;
+
+export const fetchNamespaces = ({ accessToken, refreshToken }) => {
+  const path = "/user-namespaces";
+  const config = {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      refresh_token: refreshToken,
+    }),
+  };
+  return fetch(path, config)
+    .catch(when(UnauthorizedError, () => {}))
+    .then(() => ({
+      accessToken: null,
+      refreshToken: null,
+      expiresAt: null,
+    }));
+};


### PR DESCRIPTION
## What is this change?
Switches to contacting the api for the namespaces endpoint, rather than using graphql. Makes contact more modular. 
https://github.com/sensu/sensu-enterprise-go/issues/609

## Do you need clarification on anything?
Not particularly 

## Were there any complications while making this change?
There were some, particularly with namespace icons. That system will likely have to be reworked. However, I also imagine when we will need to rework this soon either way.

## Have you reviewed and updated the documentation for this change? Is new documentation required?
No documentation required. It appears to function the same.

## How did you verify this change?
Manual testing.