### PR TITLE
Add option to clear state when error dialog is encountered

### DIFF
--- a/src/lib/component/root/ErrorRoot.js
+++ b/src/lib/component/root/ErrorRoot.js
@@ -119,9 +119,24 @@ ${"```"}`
     <ErrorDialog
       open
       actions={
-        <Button onClick={() => window.location.reload()} color="primary">
-          Reload
-        </Button>
+        <React.Fragment>
+          <Button
+            color="primary"
+            onClick={() => {
+              window.localStorage && window.localStorage.clear();
+              window.location.replace("/");
+            }}
+          >
+            {`Clear State & Reload`}
+          </Button>
+          <Button
+            color="primary"
+            variant="outlined"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </Button>
+        </React.Fragment>
       }
     >
       <Typography variant="body2">
@@ -129,7 +144,7 @@ ${"```"}`
         <br />
         <br />
         Please{" "}
-        <Link component="a" href={issueURL}>
+        <Link component="a" href={issueURL} target="_blank">
           submit an issue
         </Link>{" "}
         to help resolve this problem.


### PR DESCRIPTION
## What is this change?

Adds a button that additionally clears localStorage when the user encounters an unexpected exception.

<img width="1154" alt="Screen Shot 2019-09-13 at 11 09 34 AM" src="https://user-images.githubusercontent.com/194892/64884684-2c757d80-d617-11e9-9af6-5dd4b91f93c7.png">

## Why is this change necessary?

If the issue is related to some data in localStorage, the user could find themselves stuck until they manually clear localStorage- assuming they even know how. Giving the user the option to clear the state should help in these unfortunate cases.

Closes #173 
Closes #175

## How did you verify this change?

Manual.