### PR TITLE
Fix issue with top bar scrolling on mobile

### DIFF
--- a/src/lib/component/base/AppLayout/AppLayout.js
+++ b/src/lib/component/base/AppLayout/AppLayout.js
@@ -153,7 +153,7 @@ class AppLayout extends React.PureComponent {
   };
 
   render() {
-    const { classes, topBar, drawer, content, mobile, fullWidth } = this.props;
+    const { classes, topBar, drawer, content, fullWidth } = this.props;
 
     const contentOffset =
       CSS && CSS.supports && CSS.supports("position: sticky")

--- a/src/lib/component/base/AppLayout/AppLayout.js
+++ b/src/lib/component/base/AppLayout/AppLayout.js
@@ -150,6 +150,7 @@ class AppLayout extends React.PureComponent {
       if (state.topBarHeight === rect.height) {
         return null;
       }
+
       return { topBarHeight: rect.height };
     });
   };

--- a/src/lib/component/base/AppLayout/AppLayout.js
+++ b/src/lib/component/base/AppLayout/AppLayout.js
@@ -145,13 +145,15 @@ class AppLayout extends React.PureComponent {
       if (state.topBarHeight === rect.height) {
         return null;
       }
-
+      if (!this.props.mobile) {
+        return { topBarHeight: 0 };
+      }
       return { topBarHeight: rect.height };
     });
   };
 
   render() {
-    const { classes, topBar, drawer, content, fullWidth } = this.props;
+    const { classes, topBar, drawer, content, mobile, fullWidth } = this.props;
 
     const contentOffset =
       CSS && CSS.supports && CSS.supports("position: sticky")

--- a/src/lib/component/base/AppLayout/AppLayout.js
+++ b/src/lib/component/base/AppLayout/AppLayout.js
@@ -13,6 +13,7 @@ const styles = theme => ({
   root: {
     paddingLeft: "env(safe-area-inset-left)",
     paddingRight: "env(safe-area-inset-right)",
+    flexDirection: "column",
   },
 
   mobile: {
@@ -31,9 +32,9 @@ const styles = theme => ({
     top: 0,
     left: 0,
     right: 0,
-
+    display: "flex",
+    flexDirection: "column",
     zIndex: 1,
-
     "@supports (position: sticky)": {
       position: "sticky",
     },
@@ -63,18 +64,17 @@ const styles = theme => ({
   },
 
   banner: {
-    position: "relative",
+    width: "100%",
     zIndex: 0,
   },
 
   contentContainer: {
-    flex: 1,
     display: "flex",
-    zIndex: 0,
+    flexDirection: "row",
+    //zIndex: 0,
   },
 
   content: {
-    flex: 1,
     position: "relative",
     display: "flex",
     flexDirection: "column",
@@ -145,9 +145,9 @@ class AppLayout extends React.PureComponent {
       if (state.topBarHeight === rect.height) {
         return null;
       }
-      if (!this.props.mobile) {
+      /*if (!this.props.mobile) {
         return { topBarHeight: 0 };
-      }
+      }*/
       return { topBarHeight: rect.height };
     });
   };
@@ -157,7 +157,7 @@ class AppLayout extends React.PureComponent {
 
     const contentOffset =
       CSS && CSS.supports && CSS.supports("position: sticky")
-        ? 0
+        ? 32
         : this.state.topBarHeight;
 
     return (
@@ -175,9 +175,9 @@ class AppLayout extends React.PureComponent {
               <BannerWell />
             </div>
           </div>
-          {drawer}
-          <div style={{ height: contentOffset }} />
+          {this.props.mobile && <div style={{ height: contentOffset }} />}
           <div className={classes.contentContainer}>
+            {drawer}
             <div
               className={classnames(classes.content, {
                 [classes.contentMaxWidth]: !fullWidth,

--- a/src/lib/component/base/AppLayout/AppLayout.js
+++ b/src/lib/component/base/AppLayout/AppLayout.js
@@ -32,9 +32,11 @@ const styles = theme => ({
     top: 0,
     left: 0,
     right: 0,
+
     display: "flex",
     flexDirection: "column",
     zIndex: 1,
+
     "@supports (position: sticky)": {
       position: "sticky",
     },
@@ -69,12 +71,14 @@ const styles = theme => ({
   },
 
   contentContainer: {
+    flex: 1,
     display: "flex",
+    zIndex: 0,
     flexDirection: "row",
-    //zIndex: 0,
   },
 
   content: {
+    flex: 1,
     position: "relative",
     display: "flex",
     flexDirection: "column",
@@ -94,6 +98,7 @@ const styles = theme => ({
 
   contentMaxWidth: {
     maxWidth: 1224,
+
     [theme.breakpoints.up("md")]: {
       // align with quick nav container
       paddingTop: 24,
@@ -145,9 +150,6 @@ class AppLayout extends React.PureComponent {
       if (state.topBarHeight === rect.height) {
         return null;
       }
-      /*if (!this.props.mobile) {
-        return { topBarHeight: 0 };
-      }*/
       return { topBarHeight: rect.height };
     });
   };
@@ -157,7 +159,7 @@ class AppLayout extends React.PureComponent {
 
     const contentOffset =
       CSS && CSS.supports && CSS.supports("position: sticky")
-        ? 32
+        ? 0
         : this.state.topBarHeight;
 
     return (

--- a/src/lib/component/partial/Drawer/FullDrawer.js
+++ b/src/lib/component/partial/Drawer/FullDrawer.js
@@ -63,7 +63,16 @@ const styles = theme => ({
 
   drawer: {
     width: "280px",
-    display: "block",
+    display: "flex",
+  },
+  override: {
+    height: "100%",
+    position: "fixed",
+    "& > :first-child": {
+      top: 0,
+      zIndex: 0,
+      position: "unset",
+    },
   },
 });
 
@@ -113,7 +122,7 @@ class FullDrawer extends React.Component {
         <MaterialDrawer
           open={open}
           variant={mobile ? "temporary" : "permanent"}
-          className={classes.drawer}
+          className={classes.override}
           onClose={this.collapse}
         >
           <Loader passhrough loading={loading}>


### PR DESCRIPTION
Signed-off-by: Melissa Page <73hl10n@gmail.com>

## What is this change?
With the addition of #204 I introduced a bug where the nav bar was not scrolling properly on mobile. This fixes that.

## Why is this change necessary?
The nav bar was underneath the table bar when scrolling. Now they're both sticky.