### PR TITLE
Reduce expiry threshold to one minute

### DIFF
--- a/src/lib/apollo/tokenRefreshLink.js
+++ b/src/lib/apollo/tokenRefreshLink.js
@@ -7,7 +7,7 @@ import QueryAbortedError from "/lib/error/QueryAbortedError";
 import flagTokens from "/lib/mutation/flagTokens";
 import refreshTokens from "/lib/mutation/refreshTokens";
 
-const EXPIRY_THRESHOLD_MS = 13 * 60 * 1000;
+const EXPIRY_THRESHOLD_MS = 60 * 1000;
 const MAX_REFRESHES = 3;
 
 const tokenRefreshLink = new ApolloLink((operation, forward) => {


### PR DESCRIPTION
With changes to access token expiry, the previous value meant that the token was _always_ refreshed before a query.