### PR TITLE
Add links to labels

### DIFF
--- a/src/lib/component/icon/index.tsx
+++ b/src/lib/component/icon/index.tsx
@@ -56,7 +56,7 @@ export { default as ErrorHollowIcon } from "./ErrorHollow";
 export { default as ErrorIcon } from "./Error";
 export { default as HeartIcon } from "./Heart";
 export { default as IconGapIcon } from "./IconGap";
-export { default as Link } from "@material-ui/icons/Link";
+export { default as LinkIcon } from "@material-ui/icons/Link";
 export { default as LiveIcon } from "./Live";
 export { default as OKIcon } from "./OK";
 export { default as PolyIcon } from "./Poly";

--- a/src/lib/component/icon/index.tsx
+++ b/src/lib/component/icon/index.tsx
@@ -56,6 +56,7 @@ export { default as ErrorHollowIcon } from "./ErrorHollow";
 export { default as ErrorIcon } from "./Error";
 export { default as HeartIcon } from "./Heart";
 export { default as IconGapIcon } from "./IconGap";
+export { default as Link } from "@material-ui/icons/Link";
 export { default as LiveIcon } from "./Live";
 export { default as OKIcon } from "./OK";
 export { default as PolyIcon } from "./Poly";

--- a/src/lib/component/partial/Label/Label.js
+++ b/src/lib/component/partial/Label/Label.js
@@ -25,8 +25,9 @@ const styles = theme => ({
     borderRadius: `0 ${theme.spacing(0.5)}px ${theme.spacing(0.5)}px 0`,
   },
   icon: {
-    paddingLeft: theme.spacing(0.5),
-    verticalAlign: "top",
+    paddingLeft: theme.spacing(0.3),
+    verticalAlign: "middle",
+    fontSize: "18px",
   },
 });
 

--- a/src/lib/component/partial/Label/Label.js
+++ b/src/lib/component/partial/Label/Label.js
@@ -1,19 +1,32 @@
 import React from "/vendor/react";
 import PropTypes from "prop-types";
-import { withStyles, Typography } from "/vendor/@material-ui/core";
+import { withStyles, Typography, Link } from "/vendor/@material-ui/core";
 import { emphasize } from "/vendor/@material-ui/core/styles/colorManipulator";
+import { Link as LinkIcon } from "/lib/component/icon";
 
 const styles = theme => ({
   root: {
-    borderRadius: theme.spacing(0.5),
-    padding: `${theme.spacing(1 / 8)}px ${theme.spacing(1 / 2)}px`,
-    background: emphasize(theme.palette.background.paper, 0.05),
     color: emphasize(theme.palette.text.primary, 0.22),
     display: "inline",
     whiteSpace: "nowrap",
   },
+  key: {
+    color: theme.palette.getContrastText(theme.palette.primary.main),
+    background: theme.palette.primary.main,
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    borderRadius: `${theme.spacing(0.5)}px 0 0 ${theme.spacing(0.5)}px`,
+  },
   value: {
     color: theme.palette.text.primary,
+    background: emphasize(theme.palette.primary.main, 0.7),
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    borderRadius: `0 ${theme.spacing(0.5)}px ${theme.spacing(0.5)}px 0`,
+  },
+  icon: {
+    paddingLeft: theme.spacing(0.5),
+    verticalAlign: "top",
   },
 });
 
@@ -24,11 +37,25 @@ class Label extends React.PureComponent {
     value: PropTypes.string.isRequired,
   };
 
+  parseLink = value => {
+    const regex = /\w+:(\/?\/?)[^\s]+/;
+    if (regex.test(value)) {
+      return (
+        <Link href={value}>
+          {value}
+          <LinkIcon className={this.props.classes.icon} />
+        </Link>
+      );
+    }
+    return value;
+  };
+
   render() {
     const { classes, name, value } = this.props;
     return (
       <Typography component="span" className={classes.root}>
-        {name} | <span className={classes.value}>{value}</span>
+        <span className={classes.key}>{name}</span>
+        <span className={classes.value}>{this.parseLink(value)}</span>
       </Typography>
     );
   }

--- a/src/lib/component/partial/Label/Label.js
+++ b/src/lib/component/partial/Label/Label.js
@@ -2,7 +2,7 @@ import React from "/vendor/react";
 import PropTypes from "prop-types";
 import { withStyles, Typography, Link } from "/vendor/@material-ui/core";
 import { emphasize } from "/vendor/@material-ui/core/styles/colorManipulator";
-import { Link as LinkIcon } from "/lib/component/icon";
+import { LinkIcon } from "/lib/component/icon";
 
 const styles = theme => ({
   root: {

--- a/src/lib/component/partial/Label/Label.js
+++ b/src/lib/component/partial/Label/Label.js
@@ -39,16 +39,17 @@ class Label extends React.PureComponent {
   };
 
   parseLink = value => {
-    const regex = /\w+:(\/?\/?)[^\s]+/;
-    if (regex.test(value)) {
-      return (
-        <Link href={value}>
-          {value}
-          <LinkIcon className={this.props.classes.icon} />
-        </Link>
-      );
+    try {
+      new URL(value);
+    } catch (e) {
+      return value;
     }
-    return value;
+    return (
+      <Link href={value}>
+        {value}
+        <LinkIcon className={this.props.classes.icon} />
+      </Link>
+    );
   };
 
   render() {


### PR DESCRIPTION
## What is this change?
Closes https://github.com/sensu/sensu-go/issues/3212 

Adds links to labels, and prettifies them
<img width="495" alt="Screen Shot 2020-01-07 at 4 57 12 PM" src="https://user-images.githubusercontent.com/1707663/71941611-42332380-316f-11ea-91e1-1d7484c881af.png">

## Why is this change necessary?
Uchiwa pairity 