### PR TITLE
Ensure sorting a list view does not lose selected filters

### DIFF
--- a/src/lib/component/partial/EventsList/EventsListHeader.js
+++ b/src/lib/component/partial/EventsList/EventsListHeader.js
@@ -68,7 +68,7 @@ class EventsListHeader extends React.Component {
   };
 
   updateSort = newValue => {
-    this.props.onChangeQuery({ order: newValue });
+    this.props.onChangeQuery(params => ({ order: newValue, ...params }));
   };
 
   renderBulkActions = () => {


### PR DESCRIPTION
## What is this change?

Ensure sorting the event list view does not lose selected filters.

## Why is this change necessary?

Closes #244 

## How did you verify this change?

Manual