### PR TITLE
use topBarHeight to set Drawer's top position

### DIFF
--- a/src/lib/component/base/Drawer/Drawer.tsx
+++ b/src/lib/component/base/Drawer/Drawer.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useCallback } from "/vendor/react";
+import React, { useCallback, useContext, useState } from "/vendor/react";
 import { useTheme, Box, IconButton, Modal } from "/vendor/@material-ui/core";
 import { animated, useSpring } from "/vendor/react-spring";
 import { MenuIcon } from "/lib/component/icon";
-import ResizeObserver from "/vendor/react-resize-observer";
+import LayoutContext from "../AppLayout/Context";
 
 import { widths, heights } from "./constants";
 import { MenuItemConfig, LinkConfig, ToolbarItemConfig } from "./types";
@@ -60,8 +60,7 @@ const Drawer = ({
 }: Props) => {
   const isOpen = !!expanded || variant === "full";
 
-  const [height, setHeight] = useState(0);
-  const handlePos = React.useCallback((r) => setHeight(r.height), [setHeight]);
+  const { topBarHeight } = useContext(LayoutContext);
 
   const [openIdx, setOpenIdxState] = useState<string | null>(null);
   const setOpenIdx = useCallback(
@@ -79,6 +78,7 @@ const Drawer = ({
   const theme = useTheme();
   const color = isOpen ? theme.palette.text.primary : silver;
   const width = isOpen ? widths.full : variant === "mini" ? widths.mini : 0;
+  const height = topBarHeight > 0 ? window.innerHeight - topBarHeight : "100vh";
   const bgColor = isOpen
     ? theme.palette.background.default
     : theme.palette.primary.dark;
@@ -92,9 +92,8 @@ const Drawer = ({
   const drawer = (
     <Box
       component={animated.div}
-      height="100vh"
       position="fixed"
-      style={{ ...styles, height: height === 0 ? "auto" : height }}
+      style={{ ...styles, height: "100vh" }}
       flexDirection="column"
       paddingLeft={1}
       paddingRight={1}
@@ -153,9 +152,7 @@ const Drawer = ({
   if (variant === "mini" && expanded) {
     return (
       <React.Fragment>
-        <Box width={widths.mini} flex="0 0 auto" position="relative">
-          <ResizeObserver onResize={handlePos} />
-        </Box>
+        <Box width={widths.mini} flex="0 0 auto" position="relative" />
         <Modal disableAutoFocus onClose={onClose} open>
           {drawer}
         </Modal>
@@ -173,10 +170,8 @@ const Drawer = ({
 
   return (
     <React.Fragment>
-      <Box style={{ width }} position="relative" flex="0 0 auto">
-        <ResizeObserver onResize={handlePos} />
-      </Box>
-      {drawer}
+      <Box style={{ width }} position="relative" flex="0 0 auto" />
+      {React.cloneElement(drawer, { style: { ...drawer.props.style, height } })}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## What is this change?

Use the layout's topBarHeight to set  the top position of the drawer.

## Why is this change necessary?

Previously, contents of the drawer could be pushed outside of the container when a banner appeared.

## How did you verify this change?

Manual.