### PR TITLE
avoid using active state for menu items without link

### DIFF
--- a/src/lib/component/base/Drawer/MenuItem.tsx
+++ b/src/lib/component/base/Drawer/MenuItem.tsx
@@ -52,6 +52,9 @@ const useStyles = makeStyles(
 
 const useIsActive = (href: string) => {
   const location = useLocation();
+  if (!href) {
+    return false;
+  }
   const matches = matchPath(location.pathname, {
     path: href,
     exact: false,


### PR DESCRIPTION
Avoids using the active state for menu items that do not have a link.

Signed-off-by: James Phillips <jamesdphillips@gmail.com>