### PR TITLE
Ensures labels and annotations are clickable

### DIFF
--- a/src/lib/component/partial/ExpandableKeyValueChip/ExpandableKeyValueChip.js
+++ b/src/lib/component/partial/ExpandableKeyValueChip/ExpandableKeyValueChip.js
@@ -40,7 +40,7 @@ class ExpandableKeyValueChip extends React.Component {
         <React.Fragment key={key}>
           <ModalController
             renderModal={({ close }) => (
-              <Dialog open maxWidth TransitionComponent={Slide} onClose={close}>
+              <Dialog open maxWidth="sm" fullWidth TransitionComponent={Slide} onClose={close}>
                 <DialogTitle>{key}</DialogTitle>
                 <DialogContent>
                   <CodeBlock>
@@ -52,7 +52,7 @@ class ExpandableKeyValueChip extends React.Component {
                   </CodeBlock>
                 </DialogContent>
                 <DialogActions>
-                  <Button onClick={close} color="contrast">
+                  <Button onClick={close}>
                     Close
                   </Button>
                 </DialogActions>

--- a/src/lib/component/partial/KeyValueChip/KeyValueChip.tsx
+++ b/src/lib/component/partial/KeyValueChip/KeyValueChip.tsx
@@ -83,17 +83,41 @@ const imageExtensions = [
   ".SVG",
 ];
 
-interface KeyProps extends React.ComponentProps<"span"> {
+interface KeyProps {
   name: string;
   value?: string;
+  onClick?: () => void;
 }
 
-const stringContainer = (
-  classes: any,
-  name: string,
-  value: string,
-  ...props: any
-) => {
+const KeyValueChip = ({ name, value = "", ...props }: KeyProps) => {
+  const classes = useStyles();
+
+  let urlpath = "";
+  try {
+    const url = new URL(value);
+    urlpath = url.pathname;
+  } catch (e) {
+    // no url
+  }
+
+  if (imageExtensions.some((ext) => urlpath.toUpperCase().endsWith(ext))) {
+    return (
+      <Typography component="div" className={classes.root} variant="body2">
+        <div className={classes.imageContainer}>
+          <div
+            className={classNames(classes.base, classes.imageKey)}
+            {...props}
+          >
+            {name}
+          </div>
+          <div {...props}>
+            <img className={classes.image} src={value} alt={value} />
+          </div>
+        </div>
+      </Typography>
+    );
+  }
+
   return (
     <Typography component="span" className={classes.root} variant="body2">
       <span
@@ -113,44 +137,6 @@ const stringContainer = (
       )}
     </Typography>
   );
-};
-
-const imageContainer = (
-  classes: any,
-  name: string,
-  value: string,
-  ...props: any
-) => {
-  return (
-    <Typography component="div" className={classes.root} variant="body2">
-      <div className={classes.imageContainer}>
-        <div className={classNames(classes.base, classes.imageKey)} {...props}>
-          {name}
-        </div>
-        <div {...props}>
-          <img className={classes.image} src={value} alt={value} />
-        </div>
-      </div>
-    </Typography>
-  );
-};
-
-const KeyValueChip = ({ name, value = "", ...props }: KeyProps) => {
-  const classes = useStyles();
-
-  let urlpath = "";
-  try {
-    const url = new URL(value);
-    urlpath = url.pathname;
-  } catch (e) {
-    // no url
-  }
-
-  if (imageExtensions.some((ext) => urlpath.toUpperCase().endsWith(ext))) {
-    return imageContainer(classes, name, value, props);
-  }
-
-  return stringContainer(classes, name, value, props);
 };
 
 export default KeyValueChip;


### PR DESCRIPTION
## What is this change?

Ensures labels and annotations are clickable.

## Why is this change necessary?

A regression introduced in #278 meant that the onClick handler was no longer being passed to the chip.

## How did you verify this change?

Manual