### PR TITLE
Avoid null references in Well components

### DIFF
--- a/src/lib/component/relocation/BannerWell.tsx
+++ b/src/lib/component/relocation/BannerWell.tsx
@@ -80,7 +80,7 @@ const BannerWell = ({ elements }: Props) => {
     (id, rect) => {
       setHeights((heights) => {
         if (rect.height === heights[id]) {
-          return null;
+          return heights;
         }
 
         return { ...heights, [id]: rect.height };
@@ -93,7 +93,7 @@ const BannerWell = ({ elements }: Props) => {
     (id) => {
       setHeights((heights) => {
         if (heights[id] === undefined) {
-          return null;
+          return heights;
         }
 
         delete heights[id];

--- a/src/lib/component/relocation/ToastWell.tsx
+++ b/src/lib/component/relocation/ToastWell.tsx
@@ -52,7 +52,7 @@ const ToastWell = () => {
     (id, rect) => {
       setHeights((heights) => {
         if (rect.height === heights[id]) {
-          return null;
+          return heights;
         }
 
         return { ...heights, [id]: rect.height };
@@ -65,7 +65,7 @@ const ToastWell = () => {
     (id) => {
       setHeights((heights) => {
         if (heights[id] === undefined) {
-          return null;
+          return heights;
         }
 
         delete heights[id];


### PR DESCRIPTION
## What is this change?

Avoids settings the height of the well contents to `null`.

## Why is this change necessary?

Can cause a `TypeError` if the browser window is resized or the toast/banner is unmounted.

## How did you verify this change?

Manual