### PR TITLE
Allows last viewed cluster to be persisted

### DIFF
--- a/src/lib/apollo/client.tsx
+++ b/src/lib/apollo/client.tsx
@@ -103,6 +103,7 @@ const createClient = ({
     client,
     gql`
       query SyncLastNamespaceQuery {
+        lastCluster @client
         lastNamespace @client
       }
     `,

--- a/src/lib/apollo/resolvers/lastNamespace.graphql
+++ b/src/lib/apollo/resolvers/lastNamespace.graphql
@@ -1,9 +1,15 @@
 extend type Query {
+  "The last cluster that the client accessed."
+  lastCluster: String
+
   "The last namespace that the client accessed."
   lastNamespace: String
 }
 
 extend type Mutation {
   "Stores given pair as user's last visited namespace."
-  setLastNamespace(name: String!): Boolean
+  setLastNamespace(name: String!): Boolean @deprecated(reason: "use setLastContext instead")
+
+  "Stores given pair as user's last visited context."
+  setLastContext(namespace: String!, cluster: String!): Boolean
 }

--- a/src/lib/apollo/resolvers/lastNamespace.js
+++ b/src/lib/apollo/resolvers/lastNamespace.js
@@ -1,9 +1,21 @@
 export default {
   defaults: {
+    lastCluster: null,
     lastNamespace: null,
   },
   resolvers: {
     Mutation: {
+      setLastContext: (_, { namespace, cluster }, { cache }) => {
+        cache.writeData({
+          data: {
+            lastCluster: cluster,
+            lastNamespace: namespace,
+          },
+        });
+
+        return null;
+      },
+      // deprecated
       setLastNamespace: (_, { name }, { cache }) => {
         cache.writeData({
           data: {


### PR DESCRIPTION
Allows last viewed cluster to be persisted in localStorage and retrieved through the GraphQL interface.

Signed-off-by: James Phillips <jamesdphillips@gmail.com>
