### PR TITLE
Add namespace switcher to 404 page

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -105,7 +105,7 @@ const renderApp = () => {
                   icon: (
                     <MissingIcon />
                   ),
-                  contents: "Switch ...",
+                  contents: "Switch Namespace",
                   adornment: <SelectIcon />,
                   hint: "Select a Namespace",
                   onClick: () => {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -31,6 +31,7 @@ import {
   PreferencesIcon,
   SelectIcon,
   SilenceIcon,
+  MissingIcon,
 } from "/lib/component/icon";
 
 import { AppRoot } from "/lib/component/root";
@@ -97,171 +98,195 @@ const renderApp = () => {
       <ConfigurationProvider state={configuration}>
         <BrowserRouter>
           <AppRoot apolloClient={client}>
-            <Switch>
-              <Route exact path="/" component={LastNamespaceRedirect} />
-              <NamespaceRoute
-                path="/n/:namespace"
-                render={props => (
-                  <NavigationProvider
-                    links={[
-                      {
-                        id: "switcher",
-                        icon: (
-                          <NamespaceIcon
-                            namespace={{ name: props.match.params.namespace }}
-                          />
-                        ),
-                        contents: props.match.params.namespace,
-                        adornment: <SelectIcon />,
-                        hint: "Switch Namespace",
-                        onClick: () => {
-                          client.mutate({ mutation: openSwitcher });
+            <NavigationProvider
+              links={[
+                {
+                  id: "switcher",
+                  icon: (
+                    <MissingIcon />
+                  ),
+                  contents: "Switch ...",
+                  adornment: <SelectIcon />,
+                  hint: "Select a Namespace",
+                  onClick: () => {
+                    client.mutate({ mutation: openSwitcher });
+                  },
+                },
+              ]}
+            >
+              <Switch>
+                <Route exact path="/" component={LastNamespaceRedirect} />
+                <NamespaceRoute
+                  path="/n/:namespace"
+                  render={props => (
+                    <NavigationProvider
+                      links={[
+                        {
+                          id: "switcher",
+                          icon: (
+                            <NamespaceIcon
+                              namespace={{ name: props.match.params.namespace }}
+                            />
+                          ),
+                          contents: props.match.params.namespace,
+                          adornment: <SelectIcon />,
+                          hint: "Switch Namespace",
+                          onClick: () => {
+                            client.mutate({ mutation: openSwitcher });
+                          },
                         },
-                      },
-                      {
-                        id: "events",
-                        href: `${props.match.url}/events`,
-                        icon: <EventIcon />,
-                        contents: "Events",
-                      },
-                      {
-                        id: "entities",
-                        href: `${props.match.url}/entities`,
-                        icon: <EntityIcon />,
-                        contents: "Entities",
-                      },
-                      {
-                        id: "silences",
-                        href: `${props.match.url}/silences`,
-                        icon: <SilenceIcon />,
-                        contents: "Silences",
-                      },
-                      {
-                        id: "config",
-                        contents: "Configuration",
-                        icon: <ConfigIcon />,
-                        links: [
-                          {
-                            id: "checks",
-                            href: `${props.match.url}/checks`,
-                            contents: "Checks",
-                          },
-                          {
-                            id: "filters",
-                            href: `${props.match.url}/filters`,
-                            contents: "Filters",
-                          },
-                          {
-                            id: "handlers",
-                            href: `${props.match.url}/handlers`,
-                            contents: "Handlers",
-                          },
-                          {
-                            id: "mutators",
-                            href: `${props.match.url}/mutators`,
-                            contents: "Mutators",
-                          },
-                        ],
-                      },
-                    ]}
-                    toolbarItems={[
-                      {
-                        id: "preferences",
-                        icon: <PreferencesIcon />,
-                        hint: "Preferences",
-                        onClick: () =>
-                          client.mutate({ mutation: openPreferences }),
-                      },
-                    ]}
-                  >
-                    <Switch>
-                      <Redirect
-                        exact
-                        from={props.match.path}
-                        to={`${props.match.path}/events`}
-                      />
-                      <Route
-                        path={`${props.match.path}/checks/:check`}
-                        component={CheckDetailsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/events/:entity/:check`}
-                        component={EventDetailsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/filters/:filter`}
-                        component={EventFilterDetailsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/entities/:entity`}
-                        component={EntityDetailsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/handlers/:handler`}
-                        component={HandlerDetailsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/mutators/:mutator`}
-                        component={MutatorDetailsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/checks`}
-                        component={ChecksView}
-                      />
-                      <Route
-                        path={`${props.match.path}/entities`}
-                        component={EntitiesView}
-                      />
-                      <Route
-                        path={`${props.match.path}/events`}
-                        component={EventsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/filters`}
-                        component={EventFiltersView}
-                      />
-                      <Route
-                        path={`${props.match.path}/handlers`}
-                        component={HandlersView}
-                      />
-                      <Route
-                        path={`${props.match.path}/mutators`}
-                        component={MutatorsView}
-                      />
-                      <Route
-                        path={`${props.match.path}/silences`}
-                        component={SilencesView}
-                      />
-                      <Route render={() => "not found in namespace"} />
-                    </Switch>
-                  </NavigationProvider>
-                )}
-                fallbackComponent={NamespaceNotFoundView}
-              />
-              {/* backward compat */}
-              <Redirect exact from="/:namespace/home" to="/n/:namespace/home" />
-              <Redirect from="/:namespace/checks" to="/n/:namespace/checks" />
-              <Redirect
-                from="/:namespace/entities"
-                to="/n/:namespace/entities"
-              />
-              <Redirect from="/:namespace/events" to="/n/:namespace/events" />
-              <Redirect from="/:namespace/filters" to="/n/:namespace/filters" />
-              <Redirect
-                from="/:namespace/handlers"
-                to="/n/:namespace/handlers"
-              />
-              <Redirect
-                from="/:namespace/mutators"
-                to="/n/:namespace/mutators"
-              />
-              <Redirect
-                from="/:namespace/silences"
-                to="/n/:namespace/silences"
-              />
-              <Redirect from="/:namespace" to="/n/:namespace/events" />
-              <Route component={NotFoundView} />
-            </Switch>
+                        {
+                          id: "events",
+                          href: `${props.match.url}/events`,
+                          icon: <EventIcon />,
+                          contents: "Events",
+                        },
+                        {
+                          id: "entities",
+                          href: `${props.match.url}/entities`,
+                          icon: <EntityIcon />,
+                          contents: "Entities",
+                        },
+                        {
+                          id: "silences",
+                          href: `${props.match.url}/silences`,
+                          icon: <SilenceIcon />,
+                          contents: "Silences",
+                        },
+                        {
+                          id: "config",
+                          contents: "Configuration",
+                          icon: <ConfigIcon />,
+                          links: [
+                            {
+                              id: "checks",
+                              href: `${props.match.url}/checks`,
+                              contents: "Checks",
+                            },
+                            {
+                              id: "filters",
+                              href: `${props.match.url}/filters`,
+                              contents: "Filters",
+                            },
+                            {
+                              id: "handlers",
+                              href: `${props.match.url}/handlers`,
+                              contents: "Handlers",
+                            },
+                            {
+                              id: "mutators",
+                              href: `${props.match.url}/mutators`,
+                              contents: "Mutators",
+                            },
+                          ],
+                        },
+                      ]}
+                      toolbarItems={[
+                        {
+                          id: "preferences",
+                          icon: <PreferencesIcon />,
+                          hint: "Preferences",
+                          onClick: () =>
+                            client.mutate({ mutation: openPreferences }),
+                        },
+                      ]}
+                    >
+                      <Switch>
+                        <Redirect
+                          exact
+                          from={props.match.path}
+                          to={`${props.match.path}/events`}
+                        />
+                        <Route
+                          path={`${props.match.path}/checks/:check`}
+                          component={CheckDetailsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/events/:entity/:check`}
+                          component={EventDetailsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/filters/:filter`}
+                          component={EventFilterDetailsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/entities/:entity`}
+                          component={EntityDetailsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/handlers/:handler`}
+                          component={HandlerDetailsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/mutators/:mutator`}
+                          component={MutatorDetailsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/checks`}
+                          component={ChecksView}
+                        />
+                        <Route
+                          path={`${props.match.path}/entities`}
+                          component={EntitiesView}
+                        />
+                        <Route
+                          path={`${props.match.path}/events`}
+                          component={EventsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/filters`}
+                          component={EventFiltersView}
+                        />
+                        <Route
+                          path={`${props.match.path}/handlers`}
+                          component={HandlersView}
+                        />
+                        <Route
+                          path={`${props.match.path}/mutators`}
+                          component={MutatorsView}
+                        />
+                        <Route
+                          path={`${props.match.path}/silences`}
+                          component={SilencesView}
+                        />
+                        <Route render={() => "not found in namespace"} />
+                      </Switch>
+                    </NavigationProvider>
+                  )}
+                  fallbackComponent={NamespaceNotFoundView}
+                />
+                {/* backward compat */}
+                <Redirect
+                  exact
+                  from="/:namespace/home"
+                  to="/n/:namespace/home"
+                />
+                <Redirect from="/:namespace/checks" to="/n/:namespace/checks" />
+                <Redirect
+                  from="/:namespace/entities"
+                  to="/n/:namespace/entities"
+                />
+                <Redirect from="/:namespace/events" to="/n/:namespace/events" />
+                <Redirect
+                  from="/:namespace/filters"
+                  to="/n/:namespace/filters"
+                />
+                <Redirect
+                  from="/:namespace/handlers"
+                  to="/n/:namespace/handlers"
+                />
+                <Redirect
+                  from="/:namespace/mutators"
+                  to="/n/:namespace/mutators"
+                />
+                <Redirect
+                  from="/:namespace/silences"
+                  to="/n/:namespace/silences"
+                />
+                <Redirect from="/:namespace" to="/n/:namespace/events" />
+                <Route component={NotFoundView} />
+              </Switch>
+            </NavigationProvider>
             <ContextSwitcherKeybinding />
             <ContextSwitcherDialog />
             <PreferencesKeybinding />

--- a/src/lib/component/base/Drawer/MenuItem.tsx
+++ b/src/lib/component/base/Drawer/MenuItem.tsx
@@ -118,13 +118,7 @@ const Link = ({
         onClick={onClick}
       >
         <IconContainer icon={icon} />
-        <Box
-          clone
-          display="flex"
-          alignItems="center"
-          marginLeft={1}
-          flexGrow="1"
-        >
+        <Box clone alignItems="center" marginLeft={1} flexGrow="1" minWidth="0">
           <Typography variant="body1" color="inherit" noWrap>
             <Box component="span" fontWeight={active ? 500 : "inherit"}>
               {contents}

--- a/src/lib/component/base/Drawer/MenuItem.tsx
+++ b/src/lib/component/base/Drawer/MenuItem.tsx
@@ -1,4 +1,5 @@
 import React from "/vendor/react";
+import cx from "classnames";
 import { animated, useSpring } from "/vendor/react-spring";
 import { KeyboardArrowDownIcon } from "/lib/component/icon";
 import {
@@ -42,6 +43,10 @@ interface ListItemButtonProps {
 const useStyles = makeStyles(
   (theme: Theme) =>
     createStyles({
+      root: {
+        paddingTop: 0,
+        paddingBottom: 0,
+      },
       active: {
         backgroundColor: theme.palette.action.hover,
         fontWeight: 500,
@@ -75,12 +80,11 @@ const ListItemButton = ({
   return (
     // @ts-ignore
     <ListItem
-      className={active ? classes.active : ""}
+      className={cx(classes.root, { [classes.active]: active })}
       button
       component={to ? RouterLink : "button"}
       disabled={disabled}
       disableGutters
-      dense
       to={to}
       onClick={onClick}
     >
@@ -101,7 +105,12 @@ const Link = ({
 }: LinkProps) => {
   const active = useIsActive(href || "");
   const link = (
-    <Box display="flex" justifyContent="left" height={heights.menuitem}>
+    <Box
+      component="li"
+      display="flex"
+      justifyContent="left"
+      height={heights.menuitem}
+    >
       <ListItemButton
         active={active}
         disabled={disabled || (!href && !onClick)}

--- a/src/lib/component/icon/Missing.tsx
+++ b/src/lib/component/icon/Missing.tsx
@@ -1,0 +1,16 @@
+import React from "/vendor/react";
+import { SvgIcon } from "/vendor/@material-ui/core";
+
+const Icon = React.memo((props) => {
+  return (
+    <SvgIcon {...props}>
+      <path
+        d="M18 2a4 4 0 014 4v12a4 4 0 01-4 4H6a4 4 0 01-4-4V6a4 4 0 014-4h12zm0 2H6a2 2 0 00-2 2v12c0 1.1.9 2 2 2h12a2 2 0 002-2V6a2 2 0 00-2-2zm-6.3 10c.5 0 .8-.2.9-.6 0-.6.3-1 1.2-1.4 1-.6 1.4-1.3 1.4-2.3C15.2 8 14 7 12 7c-1.5 0-2.6.6-3 1.5-.2.2-.2.5-.2.8 0 .5.3.9.8.9s.8-.2 1-.7c.2-.6.6-1 1.3-1 .7 0 1.3.6 1.3 1.2s-.3 1-1 1.4l-.2.1c-.8.5-1.2 1-1.2 1.8v.1c0 .6.3 1 1 1zm0 3.1a1 1 0 01-1-1c0-.7.4-1.1 1-1.1a1 1 0 011.1 1c0 .7-.5 1.1-1 1.1z"
+        fillRule="evenodd"
+      />
+    </SvgIcon>
+  );
+});
+Icon.displayName = "MissingIcon";
+
+export default Icon;

--- a/src/lib/component/icon/index.tsx
+++ b/src/lib/component/icon/index.tsx
@@ -71,6 +71,7 @@ export { default as HeartIcon } from "./Heart";
 export { default as IconGapIcon } from "./IconGap";
 export { default as LinkIcon } from "@material-ui/icons/Link";
 export { default as LiveIcon } from "./Live";
+export { default as MissingIcon } from "./Missing";
 export { default as OKIcon } from "./OK";
 export { default as PolyIcon } from "./Poly";
 export { default as SmallCheckIcon } from "./SmallCheck";

--- a/src/lib/component/partial/NotFound.js
+++ b/src/lib/component/partial/NotFound.js
@@ -5,8 +5,8 @@ import Lizy from "/lib/component/base/Lizy";
 
 const styles = theme => ({
   root: {
-    flexGrow: 1,
     display: "flex",
+    flexGrow: 1,
     alignItems: "center",
     justifyContent: "center",
     textAlign: "center",
@@ -65,7 +65,7 @@ class NotFound extends React.PureComponent {
 
     return (
       <div className={classes.root}>
-        <Grid container spacing={6} className={classes.container}>
+        <Grid container spacing={2}>
           <Grid item xs={12} sm={6} className={classes.graphic}>
             <Box
               component={Lizy}

--- a/src/lib/component/view/NamespaceNotFoundView.js
+++ b/src/lib/component/view/NamespaceNotFoundView.js
@@ -14,11 +14,10 @@ class NamespaceNotFoundView extends React.PureComponent {
 
     return (
       <AppLayout disableBreadcrumbs>
-        <Box height="100vh" display="flex" alignItems="center">
-        <NotFound>
-          The namespace <strong>{namespace}</strong> could not be loaded.
-        </NotFound>
-
+        <Box height="calc(100vh - 24px)" display="flex" alignItems="center">
+          <NotFound>
+            The namespace <strong>{namespace}</strong> could not be loaded.
+          </NotFound>
         </Box>
       </AppLayout>
     );


### PR DESCRIPTION
## What is this change?

Re-adds the namespace switcher menu option to the 404 page. 

## Why is this change necessary?

Without the menu item you would either need to know a valid namespace, navigate to the app root, or logout to continue.

## How did you verify this change?

Manual