### PR TITLE
Disable resolve event button when already ok

### DIFF
--- a/src/lib/component/partial/EventsList/EventsListItem.js
+++ b/src/lib/component/partial/EventsList/EventsListItem.js
@@ -134,7 +134,7 @@ class EventListItem extends React.Component {
                 <ToolbarMenu.Item key="resolve" visible="never">
                   <ResolveMenuItem
                     iconOnly
-                    disabled={event.status === 0}
+                    disabled={event.check.status === 0}
                     onClick={this.props.onClickResolve}
                   />
                 </ToolbarMenu.Item>


### PR DESCRIPTION
## What is this change?

Disable resolve event button when status of the check is already zero.

## Why is this change necessary?

Closes #46 

## How did you verify this change?

Manual