### PR TITLE
Remove last seen field from summary on events view

### DIFF
--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsEntitySummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsEntitySummary.js
@@ -22,7 +22,6 @@ import {
   DictionaryEntry,
   InlineLink,
   CheckStatusIcon,
-  RelativeToCurrentDate,
 } from "/lib/component/base";
 import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
 import { Maybe, NamespaceLink } from "/lib/component/util";

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsEntitySummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsEntitySummary.js
@@ -57,7 +57,6 @@ class EventDetailsEntitySummary extends React.Component {
         name
         entityClass
         subscriptions
-        lastSeen
         status
         silences {
           name
@@ -148,16 +147,6 @@ class EventDetailsEntitySummary extends React.Component {
                     </DictionaryValue>
                   </DictionaryEntry>
                 )}
-                <DictionaryEntry>
-                  <DictionaryKey className={classes.smaller}>
-                    Last Seen
-                  </DictionaryKey>
-                  <DictionaryValue className={classes.fullWidth}>
-                    <Maybe value={entity.lastSeen} fallback="n/a">
-                      {val => <RelativeToCurrentDate dateTime={val} />}
-                    </Maybe>
-                  </DictionaryValue>
-                </DictionaryEntry>
                 <DictionaryEntry>
                   <DictionaryKey className={classes.smaller}>
                     Subscriptions

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsEntitySummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsEntitySummary.js
@@ -148,6 +148,10 @@ class EventDetailsEntitySummary extends React.Component {
                   </DictionaryEntry>
                 )}
                 <DictionaryEntry>
+                  <DictionaryKey>Class</DictionaryKey>
+                  <DictionaryValue>{entity.entityClass}</DictionaryValue>
+                </DictionaryEntry>
+                <DictionaryEntry>
                   <DictionaryKey className={classes.smaller}>
                     Subscriptions
                   </DictionaryKey>
@@ -171,10 +175,6 @@ class EventDetailsEntitySummary extends React.Component {
             <Grid container spacing={0}>
               <Grid item xs={12} sm={6}>
                 <Dictionary>
-                  <DictionaryEntry>
-                    <DictionaryKey>Class</DictionaryKey>
-                    <DictionaryValue>{entity.entityClass}</DictionaryValue>
-                  </DictionaryEntry>
                   <DictionaryEntry>
                     <DictionaryKey>Hostname</DictionaryKey>
                     <DictionaryValue>


### PR DESCRIPTION
## What is this change?

Unfortunately the last seen value is pulled from the event, so it is only relevant at the time the event was fired. As a result I've removed it to help avoid this confusion.

## Why is this change necessary?

Closes #72

## How did you verify this change?

Manual