### PR TITLE
Display toast when user is unable to delete event

### DIFF
--- a/src/lib/component/toast/index.js
+++ b/src/lib/component/toast/index.js
@@ -10,4 +10,8 @@ export {
   default as CreateSilenceStatusToast,
   useCreateSilenceStatusToast,
 } from "./CreateSilenceStatusToast";
+export {
+  default as ManageResourceStatusToast,
+  useManageResourceStatusToast,
+} from "./ManageResourceStatusToast";
 export { default as ResolveEventStatusToast } from "./ResolveEventStatusToast";


### PR DESCRIPTION
## What is this change?

Display a toast when a user is unable to delete an event due to lack of permissions.

## Why is this change necessary?

By virtue of the operation no longer leading to an exception, this helps relieve some of the pain from #110.
## How did you verify this change?

Manual