### PR TITLE
Trim whitespace from username when signing in

### DIFF
--- a/src/lib/component/partial/SigninDialog/SigninForm.js
+++ b/src/lib/component/partial/SigninDialog/SigninForm.js
@@ -20,7 +20,10 @@ const SignInForm = ({ disabled, error, onSubmit }) => {
 
   const handleSubmit = useCallback(
     ev => {
-      onSubmit({ username, password });
+      onSubmit({
+        username: username.trim(),
+        password: password.trim(),
+      });
       ev.preventDefault();
     },
     [username, password, onSubmit],

--- a/src/lib/component/partial/SigninDialog/SigninForm.js
+++ b/src/lib/component/partial/SigninDialog/SigninForm.js
@@ -22,7 +22,7 @@ const SignInForm = ({ disabled, error, onSubmit }) => {
     ev => {
       onSubmit({
         username: username.trim(),
-        password: password.trim(),
+        password,
       });
       ev.preventDefault();
     },


### PR DESCRIPTION
## What is this change?

Trim whitespace from username when signing in.

## Why is this change necessary?

Closes #303 

## How did you verify this change?

Manual.