### PR TITLE
Reflect check hook output on the event details view

### DIFF
--- a/src/lib/component/partial/CheckDetailsContainer/CheckDetailsExecuteAction.js
+++ b/src/lib/component/partial/CheckDetailsContainer/CheckDetailsExecuteAction.js
@@ -5,11 +5,12 @@ const CheckDetailsExecuteAction = ({ children, check, onExecute }) => {
   const createExecuteCheckStatusToast = useExecuteCheckStatusToast();
 
   return children(() => {
-    const promise = onExecute({ id: check.id });
+    const { id, subscriptions, namespace } = check;
+    const promise = onExecute({ id, subscriptions });
 
     createExecuteCheckStatusToast(promise, {
       checkName: check.name,
-      namespace: check.namespace,
+      namespace,
     });
   });
 };
@@ -20,6 +21,7 @@ CheckDetailsExecuteAction.fragments = {
       id
       name
       namespace
+      subscriptions
     }
   `,
 };

--- a/src/lib/component/partial/ChecksList/ChecksList.tsx
+++ b/src/lib/component/partial/ChecksList/ChecksList.tsx
@@ -47,6 +47,7 @@ export const checksListFragments = {
           deleted @client
           name
           namespace
+          subscriptions
           silences {
             name
             ...ClearSilencedEntriesDialog_silence
@@ -75,6 +76,7 @@ interface Check {
   deleted: boolean;
   name: string;
   namespace: string;
+  subscriptions: string[];
   silences: unknown[];
   pageInfo: unknown;
 }
@@ -165,8 +167,8 @@ const ChecksList = ({
   };
 
   const executeChecks = (checks: Check[]) => {
-    checks.forEach(({ id, name, namespace: checkNamespace }) => {
-      const promise = onExecute({ id });
+    checks.forEach(({ id, name, subscriptions, namespace: checkNamespace }) => {
+      const promise = onExecute({ id, subscriptions });
 
       createExecuteCheckStatusToast(promise, {
         checkName: name,

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -6,7 +6,6 @@ import gql from "/vendor/graphql-tag";
 
 import {
   withStyles,
-  Box,
   Card,
   CardContent,
   Divider,

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -1,9 +1,12 @@
+/* eslint-disable react/prop-types */
+
 import React from "/vendor/react";
 import PropTypes from "prop-types";
 import gql from "/vendor/graphql-tag";
 
 import {
   withStyles,
+  Box,
   Card,
   CardContent,
   Divider,
@@ -38,9 +41,11 @@ import {
 } from "/lib/component/base";
 import { Maybe, NamespaceLink } from "/lib/component/util";
 import { SilenceIcon, ExpandMoreIcon } from "/lib/component/icon";
-import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
 
+import LabelsAnnotationsCell from "/lib/component/partial/LabelsAnnotationsCell";
 import CronDescriptor from "/lib/component/partial/CronDescriptor";
+
+import EventDetailsHookSummary from "./EventDetailsHookSummary";
 
 const styles = theme => ({
   alignmentFix: {
@@ -92,6 +97,9 @@ class EventDetailsCheckSummary extends React.PureComponent {
         checkHooks {
           hooks
         }
+        hooks {
+          ...EventDetailsHookSummary_hook
+        }
         assets: runtimeAssets {
           id
           name
@@ -104,7 +112,9 @@ class EventDetailsCheckSummary extends React.PureComponent {
           ...LabelsAnnotationsCell_objectmeta
         }
       }
+
       ${LabelsAnnotationsCell.fragments.objectmeta}
+      ${EventDetailsHookSummary.fragments.hook}
     `,
     entity: gql`
       fragment EventDetailsCheckSummary_entity on Entity {
@@ -286,6 +296,27 @@ class EventDetailsCheckSummary extends React.PureComponent {
               </Typography>
             </CardContent>
           </React.Fragment>
+        )}
+        {check.hooks.length > 0 && (
+          <ExpansionPanel>
+            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="button" className={classes.expand}>
+                Check Hook Output
+              </Typography>
+            </ExpansionPanelSummary>
+            <ExpansionPanelDetails>
+              <Grid container spacing={0}>
+                {/* TODO(james): unable to pull meta fields at this time; we can, we should use name or id instead of index. */}
+                {check.hooks.map((hook, i) => (
+                  <Grid item xs={12} sm={6} key={i.toString()}>
+                    <Box marginBottom={2}>
+                      <EventDetailsHookSummary hook={hook} />
+                    </Box>
+                  </Grid>
+                ))}
+              </Grid>
+            </ExpansionPanelDetails>
+          </ExpansionPanel>
         )}
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -50,7 +50,13 @@ const styles = theme => ({
   alignmentFix: {
     boxSizing: "border-box",
   },
-  expand: { color: theme.palette.text.secondary },
+  expand: {
+    color: theme.palette.text.secondary },
+  // NOTE: Ensure that codeblock does not escape container on smaller viewports.
+  code: {
+    width: 0,
+    minWidth: "100%",
+  }
 });
 
 class EventDetailsCheckSummary extends React.PureComponent {
@@ -282,7 +288,7 @@ class EventDetailsCheckSummary extends React.PureComponent {
         {check.output ? (
           <React.Fragment>
             <Divider />
-            <CodeBlock>
+            <CodeBlock className={classes.code}>
               <CardContent>{check.output}</CardContent>
             </CodeBlock>
           </React.Fragment>

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsCheckSummary.js
@@ -297,27 +297,9 @@ class EventDetailsCheckSummary extends React.PureComponent {
             </CardContent>
           </React.Fragment>
         )}
-        {check.hooks.length > 0 && (
-          <ExpansionPanel>
-            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography variant="button" className={classes.expand}>
-                Check Hook Output
-              </Typography>
-            </ExpansionPanelSummary>
-            <ExpansionPanelDetails>
-              <Grid container spacing={0}>
-                {/* TODO(james): unable to pull meta fields at this time; we can, we should use name or id instead of index. */}
-                {check.hooks.map((hook, i) => (
-                  <Grid item xs={12} sm={6} key={i.toString()}>
-                    <Box marginBottom={2}>
-                      <EventDetailsHookSummary hook={hook} />
-                    </Box>
-                  </Grid>
-                ))}
-              </Grid>
-            </ExpansionPanelDetails>
-          </ExpansionPanel>
-        )}
+        {check.hooks.map(hook => (
+          <EventDetailsHookSummary key={hook.config.name} hook={hook} />
+        ))}
         <ExpansionPanel>
           <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
             <Typography variant="button" className={classes.expand}>

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsHookSummary.tsx
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsHookSummary.tsx
@@ -41,9 +41,15 @@ const useStyles = makeStyles(() =>
   createStyles({
     heading: {
       flex: "1 1 auto",
+      alignSelf: "center",
     },
     subheading: {
       alignSelf: "center",
+    },
+    // NOTE: Ensure that codeblock does not escape container on smaller viewports.
+    code: {
+      width: 0,
+      minWidth: "100%",
     },
   }),
 );
@@ -75,7 +81,7 @@ const EventDetailsHookSummary = ({ hook }: Props) => {
           <Duration duration={hook.duration * 1000} />
         </Typography>
       </ExpansionPanelSummary>
-      <CodeBlock>
+      <CodeBlock className={classes.code}>
         <ExpansionPanelDetails>
           <CodeHighlight
             language="bash"

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsHookSummary.tsx
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsHookSummary.tsx
@@ -2,42 +2,20 @@ import React from "/vendor/react";
 import gql from "/vendor/graphql-tag";
 
 import {
-  useTheme,
-  useMediaQuery,
-  withStyles,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
+  makeStyles,
+  createStyles,
+  ExpansionPanel,
+  ExpansionPanelSummary,
+  ExpansionPanelDetails,
   Typography,
 } from "/vendor/@material-ui/core";
 import {
-  Dictionary,
-  DictionaryKey,
-  DictionaryValue,
-  DictionaryEntry,
   KitchenTime,
   Duration,
-  InlineLink,
   CodeBlock,
   CodeHighlight,
 } from "/lib/component/base";
-import { Maybe } from "/lib/component/util";
-
-//
-// Constants
-
-const hookOutputThreshold = 127;
-
-const Strong = withStyles(() => ({
-  root: {
-    color: "inherit",
-    fontSize: "inherit",
-    fontWeight: 600,
-  },
-}))(Typography);
+import { ExpandMoreIcon } from "/lib/component/icon";
 
 interface Props {
   hook: {
@@ -52,100 +30,66 @@ interface Props {
   };
 }
 
+const fb = (str: string, fallback: string) => {
+  if (!str) {
+    return fallback;
+  }
+  return str;
+};
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    heading: {
+      flex: "1 1 auto",
+    },
+    subheading: {
+      alignSelf: "center",
+    },
+  }),
+);
+
 const EventDetailsHookSummary = ({ hook }: Props) => {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
-  const [dialogOpen, setDialogOpen] = React.useState(false);
-
-  let dialog;
-  if (dialogOpen) {
-    dialog = (
-      <Dialog
-        open
-        fullWidth
-        fullScreen={fullScreen}
-        maxWidth="md"
-        aria-labelledby={`hook-summary-dialog-title-${hook.config.name}`}
-      >
-        <DialogTitle id={`hook-summary-dialog-title-${hook.config.name}`}>
-          Hook Output
-        </DialogTitle>
-        <CodeBlock>
-          <DialogContent>{hook.output}</DialogContent>
-        </CodeBlock>
-        <DialogActions>
-          <Button autoFocus onClick={() => setDialogOpen(false)}>
-            Close
-          </Button>
-        </DialogActions>
-      </Dialog>
-    );
-  }
-
-  let output;
-  if (hook.output.length > hookOutputThreshold) {
-    output = (
-      <React.Fragment>
-        Output omitted due to length.{" "}
-        <InlineLink component="a" href="#" onClick={() => setDialogOpen(true)}>
-          Click to view
-        </InlineLink>
-        .
-      </React.Fragment>
-    );
-  } else {
-    output = (
-      <Maybe value={hook.output} fallback="Did not write to STDOUT">
-        <CodeBlock>
-          <Box padding={2}>{hook.output}</Box>
-        </CodeBlock>
-      </Maybe>
-    );
-  }
+  const classes = useStyles();
+  const panelId = `hook-panel-${hook.config.name}`;
 
   return (
-    <Dictionary>
-      <DictionaryEntry>
-        <DictionaryKey>Hook</DictionaryKey>
-        <DictionaryValue>
-          <Strong>{hook.config.name}</Strong>
-        </DictionaryValue>
-      </DictionaryEntry>
-      <DictionaryEntry>
-        <DictionaryKey>Command</DictionaryKey>
-        <DictionaryValue scrollableContent>
-          <CodeBlock>
-            <CodeHighlight
-              language="bash"
-              code={hook.config.command}
-              component="code"
-            />
-          </CodeBlock>
-        </DictionaryValue>
-      </DictionaryEntry>
-      <DictionaryEntry>
-        <DictionaryKey>Ran at</DictionaryKey>
-        <DictionaryValue>
-          <KitchenTime value={new Date(hook.executed)} />
-          {" for "}
-          <Duration duration={hook.duration * 1000} />
-        </DictionaryValue>
-      </DictionaryEntry>
-      <DictionaryEntry>
-        <DictionaryKey>Exit Code</DictionaryKey>
-        <DictionaryValue>{hook.status}</DictionaryValue>
-      </DictionaryEntry>
-      <DictionaryEntry
-        fullWidth={
-          hook.output.length <= hookOutputThreshold && hook.output.length > 0
-        }
+    <ExpansionPanel>
+      <ExpansionPanelSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls={`${panelId}-content`}
+        id={`${panelId}-header`}
       >
-        <DictionaryKey>Ouput</DictionaryKey>
-        <DictionaryValue>{output}</DictionaryValue>
-      </DictionaryEntry>
-
-      {dialog}
-    </Dictionary>
+        <Typography
+          variant="button"
+          color="textSecondary"
+          className={classes.heading}
+        >
+          Hook: {hook.config.name}
+        </Typography>
+        <Typography
+          variant="body2"
+          color="textSecondary"
+          className={classes.subheading}
+        >
+          Ran at <KitchenTime value={new Date(hook.executed)} /> for{" "}
+          <Duration duration={hook.duration * 1000} />
+        </Typography>
+      </ExpansionPanelSummary>
+      <CodeBlock>
+        <ExpansionPanelDetails>
+          <CodeHighlight
+            language="bash"
+            code={[
+              fb(hook.output.trim(), "# Did not write to STDOUT"),
+              `# Exited with status ${hook.status}`,
+            ]
+              .filter((v) => !!v)
+              .join("\n\n")}
+            component="code"
+          />
+        </ExpansionPanelDetails>
+      </CodeBlock>
+    </ExpansionPanel>
   );
 };
 

--- a/src/lib/component/partial/EventDetailsContainer/EventDetailsHookSummary.tsx
+++ b/src/lib/component/partial/EventDetailsContainer/EventDetailsHookSummary.tsx
@@ -1,0 +1,167 @@
+import React from "/vendor/react";
+import gql from "/vendor/graphql-tag";
+
+import {
+  useTheme,
+  useMediaQuery,
+  withStyles,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "/vendor/@material-ui/core";
+import {
+  Dictionary,
+  DictionaryKey,
+  DictionaryValue,
+  DictionaryEntry,
+  KitchenTime,
+  Duration,
+  InlineLink,
+  CodeBlock,
+  CodeHighlight,
+} from "/lib/component/base";
+import { Maybe } from "/lib/component/util";
+
+//
+// Constants
+
+const hookOutputThreshold = 127;
+
+const Strong = withStyles(() => ({
+  root: {
+    color: "inherit",
+    fontSize: "inherit",
+    fontWeight: 600,
+  },
+}))(Typography);
+
+interface Props {
+  hook: {
+    config: {
+      name: string;
+      command: string;
+    };
+    executed: number;
+    duration: number;
+    status: number;
+    output: string;
+  };
+}
+
+const EventDetailsHookSummary = ({ hook }: Props) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  let dialog;
+  if (dialogOpen) {
+    dialog = (
+      <Dialog
+        open
+        fullWidth
+        fullScreen={fullScreen}
+        maxWidth="md"
+        aria-labelledby={`hook-summary-dialog-title-${hook.config.name}`}
+      >
+        <DialogTitle id={`hook-summary-dialog-title-${hook.config.name}`}>
+          Hook Output
+        </DialogTitle>
+        <CodeBlock>
+          <DialogContent>{hook.output}</DialogContent>
+        </CodeBlock>
+        <DialogActions>
+          <Button autoFocus onClick={() => setDialogOpen(false)}>
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  let output;
+  if (hook.output.length > hookOutputThreshold) {
+    output = (
+      <React.Fragment>
+        Output omitted due to length.{" "}
+        <InlineLink component="a" href="#" onClick={() => setDialogOpen(true)}>
+          Click to view
+        </InlineLink>
+        .
+      </React.Fragment>
+    );
+  } else {
+    output = (
+      <Maybe value={hook.output} fallback="Did not write to STDOUT">
+        <CodeBlock>
+          <Box padding={2}>{hook.output}</Box>
+        </CodeBlock>
+      </Maybe>
+    );
+  }
+
+  return (
+    <Dictionary>
+      <DictionaryEntry>
+        <DictionaryKey>Hook</DictionaryKey>
+        <DictionaryValue>
+          <Strong>{hook.config.name}</Strong>
+        </DictionaryValue>
+      </DictionaryEntry>
+      <DictionaryEntry>
+        <DictionaryKey>Command</DictionaryKey>
+        <DictionaryValue scrollableContent>
+          <CodeBlock>
+            <CodeHighlight
+              language="bash"
+              code={hook.config.command}
+              component="code"
+            />
+          </CodeBlock>
+        </DictionaryValue>
+      </DictionaryEntry>
+      <DictionaryEntry>
+        <DictionaryKey>Ran at</DictionaryKey>
+        <DictionaryValue>
+          <KitchenTime value={new Date(hook.executed)} />
+          {" for "}
+          <Duration duration={hook.duration * 1000} />
+        </DictionaryValue>
+      </DictionaryEntry>
+      <DictionaryEntry>
+        <DictionaryKey>Exit Code</DictionaryKey>
+        <DictionaryValue>{hook.status}</DictionaryValue>
+      </DictionaryEntry>
+      <DictionaryEntry
+        fullWidth={
+          hook.output.length <= hookOutputThreshold && hook.output.length > 0
+        }
+      >
+        <DictionaryKey>Ouput</DictionaryKey>
+        <DictionaryValue>{output}</DictionaryValue>
+      </DictionaryEntry>
+
+      {dialog}
+    </Dictionary>
+  );
+};
+
+EventDetailsHookSummary.fragments = {
+  hook: gql`
+    fragment EventDetailsHookSummary_hook on Hook {
+      config {
+        name
+        command
+      }
+      duration
+      executed
+      status
+      output
+    }
+  `,
+};
+
+export default EventDetailsHookSummary;

--- a/src/lib/component/relocation/Relocation.js
+++ b/src/lib/component/relocation/Relocation.js
@@ -27,7 +27,7 @@ export const Provider = ({ children }) => {
           );
 
           if (index === -1) {
-            return null;
+            return previousElements;
           }
 
           return removeAtIndex(previousElements, index);


### PR DESCRIPTION
## What is this change?

Reflect check hook output on the event details view.

![2020-05-05 22 00 24](https://user-images.githubusercontent.com/194892/81139791-ecec0080-8f1b-11ea-9dc8-05a2022d9571.gif)

## Why is this change necessary?

Closes #38 

## How did you verify this change?

Manual.