### PR TITLE
Adds a banner for upcoming changes

### DIFF
--- a/src/lib/component/banner/RepoMoveBanner.js
+++ b/src/lib/component/banner/RepoMoveBanner.js
@@ -1,0 +1,27 @@
+import React from "/vendor/react";
+import PropTypes from "prop-types";
+import { Button } from "/vendor/@material-ui/core";
+
+import { Banner } from "/lib/component/base";
+
+class RepoMoveBanner extends React.PureComponent {
+  static propTypes = {
+    client: PropTypes.object.isRequired,
+  };
+
+  render() {
+    return (
+      <Banner
+        message="There's important changes coming to the Sensu Go OSS web UI."
+        variant="info"
+        actions={
+          <Button color="inherit" onClick={() => ""}>
+            Learn More
+          </Button>
+        }
+      />
+    );
+  }
+}
+
+export default RepoMoveBanner;

--- a/src/lib/component/banner/RepoMoveBanner.js
+++ b/src/lib/component/banner/RepoMoveBanner.js
@@ -1,6 +1,6 @@
 import React from "/vendor/react";
 import PropTypes from "prop-types";
-import { Button } from "/vendor/@material-ui/core";
+import { Button, Link } from "/vendor/@material-ui/core";
 
 import { Banner } from "/lib/component/base";
 
@@ -15,9 +15,13 @@ class RepoMoveBanner extends React.PureComponent {
         message="There's important changes coming to the Sensu Go OSS web UI."
         variant="info"
         actions={
-          <Button color="inherit" onClick={() => ""}>
+          <Link
+            style={{ color: "inherit" }}
+            component={Button}
+            href=""
+          >
             Learn More
-          </Button>
+          </Link>
         }
       />
     );

--- a/src/lib/component/banner/RepoMoveBanner.js
+++ b/src/lib/component/banner/RepoMoveBanner.js
@@ -6,19 +6,20 @@ import { Banner } from "/lib/component/base";
 
 class RepoMoveBanner extends React.PureComponent {
   static propTypes = {
-    client: PropTypes.object.isRequired,
+    onClose: PropTypes.func.isRequired,
   };
 
   render() {
     return (
       <Banner
+        onClose={this.props.onClose}
         message="There's important changes coming to the Sensu Go OSS web UI."
         variant="info"
         actions={
           <Link
             style={{ color: "inherit" }}
             component={Button}
-            href=""
+            href="https://discourse.sensu.io/t/building-a-better-ui-for-sensu/1859"
           >
             Learn More
           </Link>

--- a/src/lib/component/banner/index.js
+++ b/src/lib/component/banner/index.js
@@ -1,1 +1,2 @@
 export { default as RetryConnectionBanner } from "./RetryConnectionBanner";
+export { default as RepoMoveBanner } from "./RepoMoveBanner";

--- a/src/lib/component/partial/DeprecationAlert.js
+++ b/src/lib/component/partial/DeprecationAlert.js
@@ -1,0 +1,21 @@
+import React from "/vendor/react";
+import BannerSink from "/lib/component/relocation/BannerSink";
+import { RepoMoveBanner } from "/lib/component/banner";
+
+export function DeprecationAlert() {
+  const key = "deprecation-banner.isDismissed";
+  const isDismissed = !!localStorage.getItem(key);
+  const dismiss = React.useCallback(() => localStorage.setItem(key, "t"), []);
+
+  return (
+    <React.Fragment>
+      {!isDismissed && (
+        <BannerSink>
+          <RepoMoveBanner onClose={dismiss} />
+        </BannerSink>
+      )}
+    </React.Fragment>
+  );
+}
+
+export default DeprecationAlert;

--- a/src/lib/component/partial/DeprecationAlert.js
+++ b/src/lib/component/partial/DeprecationAlert.js
@@ -4,9 +4,9 @@ import { RepoMoveBanner } from "/lib/component/banner";
 
 export function DeprecationAlert() {
   const key = "deprecation-banner.isDismissed";
-  const [isDismissed, setDismissed] = React.useState(!!localStorage.get(key));
+  const [isDismissed, setDismissed] = React.useState(!!localStorage.getItem(key));
   const dismiss = React.useCallback(() => {
-    localStorage.set(key, "t");
+    localStorage.setItem(key, "t");
     setDismissed("t");
   }, [setDismissed]);
 

--- a/src/lib/component/partial/DeprecationAlert.js
+++ b/src/lib/component/partial/DeprecationAlert.js
@@ -4,8 +4,11 @@ import { RepoMoveBanner } from "/lib/component/banner";
 
 export function DeprecationAlert() {
   const key = "deprecation-banner.isDismissed";
-  const isDismissed = !!localStorage.getItem(key);
-  const dismiss = React.useCallback(() => localStorage.setItem(key, "t"), []);
+  const [isDismissed, setDismissed] = React.useState(!!localStorage.get(key));
+  const dismiss = React.useCallback(() => {
+    localStorage.set(key, "t");
+    setDismissed("t");
+  }, [setDismissed]);
 
   return (
     <React.Fragment>

--- a/src/lib/component/partial/GlobalAlert.js
+++ b/src/lib/component/partial/GlobalAlert.js
@@ -5,7 +5,7 @@ import gql from "/vendor/graphql-tag";
 
 import BannerSink from "/lib/component/relocation/BannerSink";
 
-import { RetryConnectionBanner } from "/lib/component/banner";
+import { RepoMoveBanner, RetryConnectionBanner } from "/lib/component/banner";
 
 class GlobalAlert extends React.PureComponent {
   static propTypes = {
@@ -17,11 +17,12 @@ class GlobalAlert extends React.PureComponent {
 
     return (
       <React.Fragment>
-        {data.localNetwork && data.localNetwork.offline && (
-          <BannerSink>
+        <BannerSink>
+          {data.localNetwork && data.localNetwork.offline && (
             <RetryConnectionBanner />
-          </BannerSink>
-        )}
+          )}
+          <RepoMoveBanner />
+        </BannerSink>
       </React.Fragment>
     );
   }

--- a/src/lib/component/partial/GlobalAlert.js
+++ b/src/lib/component/partial/GlobalAlert.js
@@ -5,7 +5,7 @@ import gql from "/vendor/graphql-tag";
 
 import BannerSink from "/lib/component/relocation/BannerSink";
 
-import { RepoMoveBanner, RetryConnectionBanner } from "/lib/component/banner";
+import { RetryConnectionBanner } from "/lib/component/banner";
 
 class GlobalAlert extends React.PureComponent {
   static propTypes = {
@@ -17,12 +17,11 @@ class GlobalAlert extends React.PureComponent {
 
     return (
       <React.Fragment>
-        <BannerSink>
-          {data.localNetwork && data.localNetwork.offline && (
+        {data.localNetwork && data.localNetwork.offline && (
+          <BannerSink>
             <RetryConnectionBanner />
-          )}
-          <RepoMoveBanner />
-        </BannerSink>
+          </BannerSink>
+        )}
       </React.Fragment>
     );
   }

--- a/src/lib/component/partial/index.js
+++ b/src/lib/component/partial/index.js
@@ -18,6 +18,7 @@ export {
 } from "./ClearSilencedEntriesDialog";
 export { default as ConfirmDelete } from "./ConfirmDelete";
 export { default as CronDescriptor } from "./CronDescriptor";
+export { default as DeprecationAlert } from "./DeprecationAlert";
 export { default as EntitiesList, EntitiesListToolbar } from "./EntitiesList";
 export { default as EntityDetailsContainer } from "./EntityDetailsContainer";
 export { default as EntityStatusDescriptor } from "./EntityStatusDescriptor";

--- a/src/lib/component/root/AppRoot.js
+++ b/src/lib/component/root/AppRoot.js
@@ -24,7 +24,11 @@ import { RelocationProvider } from "/lib/component/relocation";
 
 import { SignInView } from "/lib/component/view";
 
-import { AuthInvalidDialog, GlobalAlert } from "/lib/component/partial";
+import {
+  AuthInvalidDialog,
+  DeprecationAlert,
+  GlobalAlert,
+} from "/lib/component/partial";
 
 class AppRoot extends React.PureComponent {
   static propTypes = {
@@ -59,6 +63,7 @@ class AppRoot extends React.PureComponent {
               </Switch>
               <ResetStyles />
               <ThemeStyles />
+              <DeprecationAlert />
               <GlobalAlert />
             </AppThemeProvider>
           </KeybindProvider>


### PR DESCRIPTION
## What is this change?
Closes [#1069](https://github.com/sensu/sensu-enterprise-go/issues/1069)

<img width="1240" alt="Screen Shot 2020-06-04 at 12 04 26" src="https://user-images.githubusercontent.com/1707663/83800103-c07eed80-a65b-11ea-929e-f88c280e3a7f.png">

## Why is this change necessary?
We want to inform people about changes coming to the web ui/repo