### PR TITLE
Properly base64 encode characters outside of the Latin1 range

### DIFF
--- a/src/lib/util/authAPI.js
+++ b/src/lib/util/authAPI.js
@@ -1,6 +1,7 @@
 import { parseUNIX } from "/lib/util/date";
 import { memoize, when } from "/lib/util/promise";
 import { UnauthorizedError } from "/lib/error/FetchError";
+import { btoa } from "/app/util/base64";
 import fetch from "/lib/util/fetch";
 
 /*
@@ -38,7 +39,7 @@ export const createTokens = memoize(
       method: "GET",
       headers: {
         Accept: "application/json",
-        Authorization: `Basic ${window.btoa(`${username}:${password}`)}`,
+        Authorization: `Basic ${btoa(`${username}:${password}`)}`,
       },
     };
 

--- a/src/lib/util/authAPI.js
+++ b/src/lib/util/authAPI.js
@@ -1,7 +1,7 @@
 import { parseUNIX } from "/lib/util/date";
 import { memoize, when } from "/lib/util/promise";
 import { UnauthorizedError } from "/lib/error/FetchError";
-import { btoa } from "/app/util/base64";
+import { btoa } from "/lib/util/base64";
 import fetch from "/lib/util/fetch";
 
 /*

--- a/src/lib/util/base64.ts
+++ b/src/lib/util/base64.ts
@@ -1,0 +1,7 @@
+// Properly encode unicode characters
+export const btoa = (str: string) =>
+  window.btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (m, p) =>
+      String.fromCharCode(parseInt("0x" + p, 16)),
+    ),
+  );


### PR DESCRIPTION
Fixes issue where those with credentials that included non-ascii characters were unable to authenticate.

---

Signed-off-by: James Phillips <jamesdphillips@gmail.com>