### PR TITLE
Added option in scripts/serve.js. Updated INSTALL.MD documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,13 @@ increase the system-wide limit:
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
+## Unsigned SSL Certificates for sensu-backend
+In development, you might not have a signed CA certificate for the API URL for the sensu backend. Set this environment variable (`NODE_PROXY_SECURE`) to false to turn off SSL cert verification.
+
+```bash
+NODE_PROXY_SECURE=false NODE_ENV=development PORT=5000 API_URL=https://my-sensu-backend-api:8080 yarn node scripts serve --modules-folder /opt/sensu/yarn/node_modules
+```
+
 ## Running in Production
 
 In production, you probably don't want the source code files owned by the

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -24,6 +24,7 @@ app.use(compression());
 app.use(
   createProxyMiddleware(proxyPaths, {
     target: apiUrl,
+    secure: process.env.NODE_PROXY_SECURE === "false" ? false : true,
     logLevel: process.env.NODE_ENV === "development" ? "silent" : "info",
   }),
 );


### PR DESCRIPTION
## What is this change?

Adding a option through an environment variable (NODE_PROXY_SECURE) to set "secure: false" in the proxy config in the serve.js file. If the environment variable is not set it will default to "secure: true"

## Why is this change necessary?

Current config requires a CA signed SSL certificate even in a development environment. 

## Have you reviewed and updated the documentation for this change? Is new documentation required?

Yes, I have updated the INSTALL.MD file. 

## How did you verify this change?

Deployed open source sensu web with my changes in my testing enviroment. The 500 error I was seeing no longer appeared after the change and I was allowed to connect to the sensu-backend service. 

## Related Issue #

https://github.com/sensu/web/issues/362
