### PR TITLE
Small typo when clicking on event after execute

### DIFF
--- a/src/lib/component/toast/ExecuteCheckStatusToast.js
+++ b/src/lib/component/toast/ExecuteCheckStatusToast.js
@@ -43,8 +43,8 @@ const ExecuteCheckStatusToast = ({
             <InlineLink
               component={NamespaceLink}
               namespace={namespace}
-              to={`/events?filter=${encodeURIComponent(
-                `check.name === "${checkName}"${
+              to={`/events?filters=${encodeURIComponent(
+                `check:${checkName}${
                   entityName ? ` && entity.name === "${entityName}"` : ""
                 }`,
               )}`}


### PR DESCRIPTION
## What is this change?

Small typo when clicking on event after execute

## Why is this change necessary?

Yes, without this change when clicking popup in events after executing - you'll get and error
## Does your change need a Changelog entry?
No

## Do you need clarification on anything?

No
## Were there any complications while making this change?

Simple

## Have you reviewed and updated the documentation for this change? Is new documentation required?

No update needed 

## How did you verify this change?

Added this code to our environment 
