### PR TITLE
Fix for silence entities/checks for a specific duration

### DIFF
--- a/src/lib/component/partial/SilenceEntryForm/SilenceEntryFormExpirationPanel.js
+++ b/src/lib/component/partial/SilenceEntryForm/SilenceEntryFormExpirationPanel.js
@@ -16,16 +16,24 @@ import { withField } from "/vendor/@10xjs/form";
 
 import Panel from "./SilenceEntryFormPanel";
 
-const DEFAULT_EXPIRE_DURATION = 3600;
+const DEFAULT_EXPIRE_DURATION = 24;
 
 class SilenceEntryFormExpirationPanel extends React.PureComponent {
   static propTypes = {
     expireOnResolve: PropTypes.object.isRequired,
     expire: PropTypes.object.isRequired,
+    expireAt: PropTypes.object.isRequired,
   };
 
   render() {
-    const { expireOnResolve, expire } = this.props;
+    const { expireOnResolve, expire, expireAt } = this.props;
+
+    this._addHours = function addHours(numOfHours, date = new Date()) {
+      const dateCopy = new Date(date.getTime());
+      dateCopy.setTime(dateCopy.getTime() + numOfHours * 60 * 60 * 1000);
+      dateCopy.toISOString();
+      return dateCopy;
+    }
 
     const expireAfterDuration = expire.rawValue > 0;
 
@@ -41,7 +49,7 @@ class SilenceEntryFormExpirationPanel extends React.PureComponent {
         expireOnResolve.input.checked ? "on resolved check" : null,
         expireAfterDuration
           ? `after ${expire.rawValue} ${
-              expire.rawValue === 1 ? "second" : "seconds"
+              expire.rawValue === 1 ? "hour" : "hours"
             }`
           : null,
       ]
@@ -76,6 +84,11 @@ class SilenceEntryFormExpirationPanel extends React.PureComponent {
                       ? this._lastExprireValue || DEFAULT_EXPIRE_DURATION
                       : -1,
                   );
+                  expireAt.setValue(
+                    checked
+                      ? this._addHours(this._lastExprireValue || DEFAULT_EXPIRE_DURATION)
+                      : undefined,
+                  );
                 }}
               />
             }
@@ -89,7 +102,7 @@ class SilenceEntryFormExpirationPanel extends React.PureComponent {
               label="Expire after"
               InputProps={{
                 endAdornment: (
-                  <InputAdornment position="end">seconds</InputAdornment>
+                  <InputAdornment position="end">hour(s)</InputAdornment>
                 ),
               }}
               {...expire.composeInput({
@@ -97,6 +110,10 @@ class SilenceEntryFormExpirationPanel extends React.PureComponent {
                   if (!event.target.value) {
                     this._lastExprireValue = undefined;
                     expire.setValue(-1);
+                    expireAt.setValue(undefined);
+                  }
+                  else {
+                    expireAt.setValue(this._addHours(event.target.value));
                   }
                 },
               })}
@@ -119,6 +136,15 @@ export default compose(
       const number = parseInt(value, 10);
       return Number.isNaN(number) ? -1 : number;
     },
+    format(value) {
+      if (value === undefined || value === null || value === -1) {
+        return "";
+      }
+      return `${value}`;
+    },
+  }),
+  withField("expireAt", {
+    path: "props.expireAt",
     format(value) {
       if (value === undefined || value === null || value === -1) {
         return "";


### PR DESCRIPTION
Fix for silence entities/checks for a specific duration. 
The duration is in hours now.

Signed-off-by: alrf <alrf@yandex.com>

## What is this change?

<!-- A brief one-sentence-ish description of the change. -->


## Why is this change necessary?

<!-- A brief description of why the change of behavior is necessary. -->

https://github.com/sensu/web/issues/412

## Does your change need a Changelog entry?

<!--
Spoiler alert, it probably does. Generally speaking, your change needs a changelog. For more information, see [CONTRIBUTING.md](https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md#changelog).
-->

## Do you need clarification on anything?

<!-- Is there anything the reviewer should specifically look at? Are you unsure of any portion of this change? Omit if not applicable. -->


## Were there any complications while making this change?

<!--
If anything went awry while working on this change or if you ran into systemic issues preventing progress, please leave feedback on those issues here. Examples might include:

- refactoring was required
- interfaces were unclear
- it was difficult to get the information you needed to complete the issue

Feel free to edit this portion of the PR once the review is complete to add any comments about the review process itself.
-->

## Have you reviewed and updated the documentation for this change? Is new documentation required?

<!--
Read any documentation that relates to the change you're making. If it needs
updating, update it and file a PR. The PR should be linked to this PR
or the original issue.
-->

## How did you verify this change?

<!--
Aside from unit/integration tests, please describe the e2e steps to verify this change.

Eng@Sensu: Add the test case to the TestRail QA plan, and write an automated Rspec test, if applicable.
The corresponding sensu-go-qa-crucible PR or issue should be linked here.
-->

Tested in different options with sensu-go v6.7.2.