### PR TITLE
Upgrade Hashing Function

### DIFF
--- a/config/app.webpack.config.js
+++ b/config/app.webpack.config.js
@@ -9,6 +9,10 @@ import makeConfig from "./base.webpack.config";
 const root = fs.realpathSync(process.cwd());
 const outputPath = path.join(root, "build/app");
 
+import crypto from "crypto";
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+
 export default makeConfig({
   name: "app",
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tsconfig.json"
   ],
   "engines": {
-    "node": ">=14 <16",
+    "node": ">=14",
     "npm": ">= 5.2.0",
     "yarn": "^1.13.0"
   },


### PR DESCRIPTION
##What is this change?
This PR upgrades crypto hashing function of this application to make it compatible with the most current version of Node.js

##Why is this change necessary?
The current state of the application will only build with Node versions <=16. These minimal changes update webpack, so it can successfully build and run this application with the latest version(s) of NodeJS - currently 20.2.0.

##Does your change need a Changelog entry?
Yes.

Refactored webpack config file to use most current Node.js crypto hashing function to allow app to build and run with current version(s) of Node.

##Do you need clarification on anything?
No

##Were there any complications while making this change?
No

##Have you reviewed and updated the documentation for this change? Is new documentation required?
No new documentation is required for these changes. 

Users can now successfully build the application with both current and deprecated Node versions following the same existing documentation.

##How did you verify this change?
NOTE: Successfully tested with Node 15.14.0, 16.20.1 and 20.2.0 using a locally hosted Sensu Go backend running in a docker container. All elements of frontend react app were properly functioning.

To verify this change, follow these steps:

Verify application does not work with Node 20.2.0
a) Switch to master branch
b) Update local version of nodeJS within 14 - 16 (use NVM or preferred version manager)
c) Attempt to build application (should successfully build and launch)
d) Switch to node version >=17 (preferably 20.2.0 - most current stable release) and attempt to build application(should fail)

Verify application does work with Node 20.2.0
a) Switch to branch upgrade-hashing-function
b) Update local version of nodeJS to 20.2.0 (use NVM or preferred version manager)
c) c) Attempt to build application (should successfully build and launch)